### PR TITLE
Import Status Codes and Medication Tests

### DIFF
--- a/fixtures/cat1_good.xml
+++ b/fixtures/cat1_good.xml
@@ -1333,6 +1333,224 @@
               <value code="428024001" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="clinical trial participant" xsi:type="CD"/>
             </observation>
           </entry>
+          <entry>
+            <act classCode="ACT" moodCode="EVN" >
+              <!-- Medication, Administered template -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.42"/>
+              <id root="50f84c187042f98775000108"/>
+              <code code="416118004" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Administration"/>
+              <statusCode code="completed"/>
+              <effectiveTime xsi:type="IVL_TS">
+                <low value='20061203201716'/>
+                <high value='20061204072502'/>
+              </effectiveTime>
+              <entryRelationship typeCode="COMP">
+                <substanceAdministration classCode="SBADM" moodCode="EVN">
+                  <!-- Medication Activity (consolidation) template -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                  <id root="278dade0-4307-0130-0add-680688cbd736"/>
+                  <text>Medication, Administered: Pneumococcal Vaccine (Code List: 2.16.840.1.113883.3.464.1003.110.12.1027)</text>
+                  <statusCode code="completed"/>
+                  <effectiveTime xsi:type="IVL_TS">
+                    <low value='20061203201716'/>
+                    <high value='20061204072502'/>
+                  </effectiveTime>
+                  <consumable>
+                    <manufacturedProduct classCode="MANU">
+                      <!-- Medication Information (consolidation) template -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                      <id root="278db0f0-4307-0130-0add-680688cbd736"/>
+                      <manufacturedMaterial>
+                        <code code="33" codeSystem="2.16.840.1.113883.6.59" sdtc:valueSet="2.16.840.1.113883.3.464.1003.110.12.1027"><originalText>Medication, Administered: Pneumococcal Vaccine (Code List: 2.16.840.1.113883.3.464.1003.110.12.1027)</originalText></code>
+                      </manufacturedMaterial>
+                    </manufacturedProduct>
+                  </consumable>
+                </substanceAdministration>
+              </entryRelationship>
+            </act>
+          </entry>
+          <entry>
+            <!--Medication Order -->
+            <substanceAdministration classCode="SBADM" moodCode="RQO" negationInd="true">
+              <templateId root="2.16.840.1.113883.10.20.22.4.42"/>
+              <!-- Medication, Order template -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.47"/>
+              <id root="50f84c1a7042f987750001d2"/>
+              <text>Medication, Order: Beta Blocker Therapy for LVSD (Code List: 2.16.840.1.113883.3.526.3.1184)</text>
+              <statusCode code="new"/>
+              <effectiveTime xsi:type="IVL_TS">
+                <low value='20000328001401'/>
+                <high value='20000328012924'/>
+              </effectiveTime>
+              <consumable>
+                <manufacturedProduct classCode="MANU">
+                  <!-- Medication Information (consolidation) template -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                  <id root="28c33d70-4307-0130-0add-680688cbd736"/>
+                  <manufacturedMaterial>
+                    <code code="866439" codeSystem="2.16.840.1.113883.6.88" sdtc:valueSet="2.16.840.1.113883.3.526.3.1184"><originalText>Medication, Order: Beta Blocker Therapy for LVSD (Code List: 2.16.840.1.113883.3.526.3.1184)</originalText></code>
+                  </manufacturedMaterial>
+                </manufacturedProduct>
+              </consumable>
+              <entryRelationship typeCode="RSON">
+                <observation classCode="OBS" moodCode="EVN">
+                  <templateId root="2.16.840.1.113883.10.20.24.3.88"/>  
+                  <code code="410666004" 
+                        codeSystem="2.16.840.1.113883.6.96"
+                        displayName="reason" 
+                        codeSystemName="SNOMED CT"/>
+                  <statusCode code="completed"/>
+                  <effectiveTime value='20000328001401'/>
+                  <value xsi:type="CD" 
+                       code="79899007" 
+                       codeSystem=""/>
+                </observation>
+              </entryRelationship>
+            </substanceAdministration>
+          </entry>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <!-- Discharge Medication Entry -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.105"/>
+              <id root="50f84dbb7042f9366f000189"/>
+              <code code="10183-2" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Discharge medication"/>
+              <statusCode code="active"/>
+              <effectiveTime>
+                <low value="20050430111813"/>
+              </effectiveTime>
+              <entryRelationship typeCode="SUBJ">
+                <substanceAdministration moodCode="EVN" classCode="SBADM">
+                  <!-- Medication Activity (consolidation) template -->
+                  <templateId root="2.16.840.1.113883.10.20.22.4.16"/>
+                  <!-- Medication, Active template -->
+                  <templateId root="2.16.840.1.113883.10.20.24.3.41"/>
+                  <id root="21305e00-4308-0130-0ade-680688cbd736"/>
+                  <text>Medication, Discharge: Antithrombotic Therapy (Code List: 2.16.840.1.113883.3.117.1.7.1.201)</text>
+                  <statusCode code="active"/>
+                  <effectiveTime xsi:type="IVL_TS">
+                    <low value="20050430111813"/>
+                    <high value="20050501022146"/>
+                  </effectiveTime>
+                  <!-- Attribute: dose -->
+                  <consumable>
+                    <manufacturedProduct classCode="MANU">
+                      <!-- Medication Information (consolidation) template -->
+                      <templateId root="2.16.840.1.113883.10.20.22.4.23"/>
+                      <id root="21306190-4308-0130-0ade-680688cbd736"/>
+                      <manufacturedMaterial>
+                        <code nullFlavor="UNK">
+                          <originalText>Medication, Discharge: Antithrombotic Therapy (Code List: 2.16.840.1.113883.3.117.1.7.1.201)</originalText>
+                          <translation code="994435" codeSystem="2.16.840.1.113883.6.88"/>
+                        </code>
+                      </manufacturedMaterial>
+                      <manufacturerOrganization>
+                        <name>Medication Factory Inc.</name>
+                      </manufacturerOrganization>
+                    </manufacturedProduct>
+                  </consumable>
+                </substanceAdministration>
+              </entryRelationship>
+            </act>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- consolidation CDA Allergy Observation template -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+              <templateId root="2.16.840.1.113883.10.20.24.3.46"/>
+              <id root="50f84c1a7042f987750001db"/>
+              <code code="ASSERTION" 
+                    displayName="Assertion" 
+                    codeSystem="2.16.840.1.113883.5.4" 
+                    codeSystemName="ActCode"/>
+              <statusCode code="completed"/>
+              <effectiveTime>
+                  <low value="20061203201716"/>
+              </effectiveTime>
+              <value xsi:type="CD" 
+                     code="59037007" 
+                     displayName="Drug intolerance"
+                     codeSystem="2.16.840.1.113883.6.96" 
+                     codeSystemName="SNOMED CT"/>
+
+              <participant typeCode="CSM">
+                <participantRole classCode="MANU">
+                  <playingEntity classCode="MMAT">
+                    <code code="998695" codeSystem="2.16.840.1.113883.6.88" sdtc:valueSet="2.16.840.1.113883.3.526.3.1174"><originalText>Medication, Intolerance: Beta Blocker Therapy (Code List: 2.16.840.1.113883.3.526.3.1174)</originalText></code>
+                    <text>Medication, Intolerance: Beta Blocker Therapy (Code List: 2.16.840.1.113883.3.526.3.1174)</text>
+                  </playingEntity>
+                </participantRole>
+              </participant>
+            </observation>
+          </entry>
+          <entry>
+            <observation classCode="OBS" moodCode="EVN">
+              <!-- consolidation CDA Allergy observation template -->
+              <templateId root="2.16.840.1.113883.10.20.22.4.7"/>
+              <!--  Medication Allergy -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.44"/>
+              <id root="50f84db97042f9366f00000e"/>
+              <code code="ASSERTION" displayName="Assertion" codeSystem="2.16.840.1.113883.5.4" codeSystemName="ActCode"/>
+              <statusCode code="completed"/>
+              <effectiveTime>
+                <low value='19790809140056'/>
+              </effectiveTime>
+              <value code="62014003" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Adverse drug effect" xsi:type="CD"/>
+
+              <participant typeCode="CSM">
+                <participantRole classCode="MANU">
+                  <playingEntity classCode="MMAT">
+                    <code code="996994" codeSystem="2.16.840.1.113883.6.88" sdtc:valueSet="2.16.840.1.113883.3.666.5.626"><originalText>Medication, Adverse Effects: Hospital Measures-Aspirin (Code List: 2.16.840.1.113883.3.666.5.626)</originalText></code>
+                    <name>Medication, Adverse Effects: Hospital Measures-Aspirin (Code List: 2.16.840.1.113883.3.666.5.626)</name>
+                  </playingEntity>
+                </participantRole>
+              </participant>
+            </observation>
+          </entry>
+          <entry>
+            <act classCode="ACT" moodCode="EVN" >
+              <!-- Communication from provider to provider -->
+              <templateId root="2.16.840.1.113883.10.20.24.3.4"/>
+              <id root="50f84c1d7042f987750003bf"/>
+              <code code="371545006" codeSystem="2.16.840.1.113883.6.96" sdtc:valueSet="2.16.840.1.113883.3.464.1003.121.12.1006"><originalText>Communication: From Provider to Provider: Consultant Report (Code List: 2.16.840.1.113883.3.464.1003.121.12.1006)</originalText></code>
+              <text>Communication: From Provider to Provider: Consultant Report (Code List: 2.16.840.1.113883.3.464.1003.121.12.1006)</text>
+              <statusCode code="completed"/>
+              <effectiveTime>
+                <low value='19810627142601'/>
+              </effectiveTime>
+              <participant typeCode="AUT">
+                <participantRole classCode="ASSIGNED">
+                  <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
+                </participantRole>
+              </participant>
+
+              <participant typeCode="IRCP">
+                <participantRole classCode="ASSIGNED">
+                  <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
+                </participantRole>
+              </participant>
+            </act>
+          </entry>
+          <entry>
+            <act classCode="ACT" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.24.3.3"/>
+              <id root="50cf48409eae47465700008f"/>  
+              <code nullFlavor="UNK" ><originalText>Communication: From Provider to Patient: Asthma Management Plan (Code List: 2.16.840.1.113883.3.117.1.7.1.131)</originalText><translation code="69981-9" codeSystem="2.16.840.1.113883.6.1"/>
+              </code>
+              <text>Communication: From Provider to Patient: Asthma Management Plan (Code List: 2.16.840.1.113883.3.117.1.7.1.131)</text>
+              <statusCode code="completed"/>
+              <effectiveTime>
+              <low value='20100605220000'/>
+              </effectiveTime>             
+              <participant typeCode="AUT">
+                <participantRole classCode="ASSIGNED">
+                  <code code="158965000" codeSystem="2.16.840.1.113883.6.96" codeSystemName="SNOMED CT" displayName="Medical Practitioner"/>
+                </participantRole>
+              </participant>
+              <participant typeCode="IRCP">
+                <participantRole classCode="PAT"/>
+              </participant> 
+            </act>
+          </entry>
         </section>
       </component>
     </structuredBody>

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -37,7 +37,7 @@ func Read_patient(path string) string {
 
 	//encounter performed
 	var encounterPerformedXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")
-	rawEncountersPerformed := ExtractSection(patientElement, encounterPerformedXPath, EncounterPerformedExtractor, "2.16.840.1.113883.3.560.1.79")
+	rawEncountersPerformed := ExtractSection(patientElement, encounterPerformedXPath, EncounterPerformedExtractor, "2.16.840.1.113883.3.560.1.79", "performed")
 	patient.Encounters = make([]models.Encounter, len(rawEncountersPerformed))
 	for i := range rawEncountersPerformed {
 		patient.Encounters[i] = rawEncountersPerformed[i].(models.Encounter)
@@ -45,14 +45,14 @@ func Read_patient(path string) string {
 
 	//encounter ordered
 	var encounterOrderXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']")
-	rawEncounterOrders := ExtractSection(patientElement, encounterOrderXPath, EncounterOrderExtractor, "2.16.840.1.113883.3.560.1.83")
+	rawEncounterOrders := ExtractSection(patientElement, encounterOrderXPath, EncounterOrderExtractor, "2.16.840.1.113883.3.560.1.83", "ordered")
 	for i := range rawEncounterOrders {
 		patient.Encounters = append(patient.Encounters, rawEncounterOrders[i].(models.Encounter))
 	}
 
 	//diagnosis active
 	var diagnosisActiveXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.11']")
-	rawDiagnosesActive := ExtractSection(patientElement, diagnosisActiveXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.2")
+	rawDiagnosesActive := ExtractSection(patientElement, diagnosisActiveXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.2", "active")
 	patient.Conditions = make([]models.Condition, len(rawDiagnosesActive))
 	for i := range rawDiagnosesActive {
 		patient.Conditions[i] = rawDiagnosesActive[i].(models.Condition)
@@ -60,14 +60,14 @@ func Read_patient(path string) string {
 
 	//diagnosis inactive
 	var diagnosisInactiveXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.13']")
-	rawDiagnosesInactive := ExtractSection(patientElement, diagnosisInactiveXPath, DiagnosisInactiveExtractor, "2.16.840.1.113883.3.560.1.2")
+	rawDiagnosesInactive := ExtractSection(patientElement, diagnosisInactiveXPath, DiagnosisInactiveExtractor, "2.16.840.1.113883.3.560.1.23", "inactive")
 	for i := range rawDiagnosesInactive {
 		patient.Conditions = append(patient.Conditions, rawDiagnosesInactive[i].(models.Condition))
 	}
 
 	//lab results
 	var labResultXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.40']")
-	rawLabResults := ExtractSection(patientElement, labResultXPath, LabResultExtractor, "2.16.840.1.113883.3.560.1.12")
+	rawLabResults := ExtractSection(patientElement, labResultXPath, LabResultExtractor, "2.16.840.1.113883.3.560.1.12", "")
 	patient.LabResults = make([]models.LabResult, len(rawLabResults))
 	for i := range rawLabResults {
 		patient.LabResults[i] = rawLabResults[i].(models.LabResult)
@@ -75,14 +75,14 @@ func Read_patient(path string) string {
 
 	//lab orders
 	var labOrderXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.37']")
-	rawLabOrders := ExtractSection(patientElement, labOrderXPath, LabOrderExtractor, "2.16.840.1.113883.3.560.1.50")
+	rawLabOrders := ExtractSection(patientElement, labOrderXPath, LabOrderExtractor, "2.16.840.1.113883.3.560.1.50", "ordered")
 	for i := range rawLabOrders {
 		patient.LabResults = append(patient.LabResults, rawLabOrders[i].(models.LabResult))
 	}
 
 	//insurance provider
 	var insuranceProviderXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']")
-	rawInsuranceProviders := ExtractSection(patientElement, insuranceProviderXPath, InsuranceProviderExtractor, "2.16.840.1.113883.3.560.1.405")
+	rawInsuranceProviders := ExtractSection(patientElement, insuranceProviderXPath, InsuranceProviderExtractor, "2.16.840.1.113883.3.560.1.405", "")
 	patient.InsuranceProviders = make([]models.InsuranceProvider, len(rawInsuranceProviders))
 	for i := range rawInsuranceProviders {
 		patient.InsuranceProviders[i] = rawInsuranceProviders[i].(models.InsuranceProvider)
@@ -90,7 +90,7 @@ func Read_patient(path string) string {
 
 	// diagnostic study order
 	var diagnosticStudyOrderXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.17']")
-	rawDiagnosticStudyOrders := ExtractSection(patientElement, diagnosticStudyOrderXPath, DiagnosticStudyOrderExtractor, "2.16.840.1.113883.3.560.1.40")
+	rawDiagnosticStudyOrders := ExtractSection(patientElement, diagnosticStudyOrderXPath, DiagnosticStudyOrderExtractor, "2.16.840.1.113883.3.560.1.40", "ordered")
 	patient.Procedures = make([]models.Procedure, len(rawDiagnosticStudyOrders))
 	for i := range rawDiagnosticStudyOrders {
 		patient.Procedures[i] = rawDiagnosticStudyOrders[i].(models.Procedure)
@@ -98,21 +98,21 @@ func Read_patient(path string) string {
 
 	// transfer from
 	var transferFromXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.81']")
-	rawTransferFroms := ExtractSection(patientElement, transferFromXPath, TransferFromExtractor, "2.16.840.1.113883.3.560.1.71")
+	rawTransferFroms := ExtractSection(patientElement, transferFromXPath, TransferFromExtractor, "2.16.840.1.113883.3.560.1.71", "")
 	for i := range rawTransferFroms {
 		patient.Encounters = append(patient.Encounters, rawTransferFroms[i].(models.Encounter))
 	}
 
 	// transfer to
 	var transferToXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.82']")
-	rawTransferTos := ExtractSection(patientElement, transferToXPath, TransferToExtractor, "2.16.840.1.113883.3.560.1.72")
+	rawTransferTos := ExtractSection(patientElement, transferToXPath, TransferToExtractor, "2.16.840.1.113883.3.560.1.72", "")
 	for i := range rawTransferTos {
 		patient.Encounters = append(patient.Encounters, rawTransferTos[i].(models.Encounter))
 	}
 
 	//medication active
 	var medicationActiveXPath = xpath.Compile("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")
-	rawMedicationActives := ExtractSection(patientElement, medicationActiveXPath, MedicationActiveExtractor, "2.16.840.1.113883.3.560.1.13")
+	rawMedicationActives := ExtractSection(patientElement, medicationActiveXPath, MedicationActiveExtractor, "2.16.840.1.113883.3.560.1.13", "active")
 	patient.Medications = make([]models.Medication, len(rawMedicationActives))
 	for i := range rawMedicationActives {
 		patient.Medications[i] = rawMedicationActives[i].(models.Medication)
@@ -120,147 +120,147 @@ func Read_patient(path string) string {
 
 	//medication dispensed
 	var medicationDispensedXPath = xpath.Compile("./cda:entry/cda:supply[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.45']")
-	rawMedicationDispenseds := ExtractSection(patientElement, medicationDispensedXPath, MedicationDispensedExtractor, "2.16.840.1.113883.3.560.1.8")
+	rawMedicationDispenseds := ExtractSection(patientElement, medicationDispensedXPath, MedicationDispensedExtractor, "2.16.840.1.113883.3.560.1.8", "dispensed")
 	for i := range rawMedicationDispenseds {
 		patient.Medications = append(patient.Medications, rawMedicationDispenseds[i].(models.Medication))
 	}
 
 	//medication administered
 	var medicationAdministeredXPath = xpath.Compile("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")
-	rawMedicationAdministereds := ExtractSection(patientElement, medicationAdministeredXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.14")
+	rawMedicationAdministereds := ExtractSection(patientElement, medicationAdministeredXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.14", "administered")
 	for i := range rawMedicationAdministereds {
 		patient.Medications = append(patient.Medications, rawMedicationAdministereds[i].(models.Medication))
 	}
 
 	//medication ordered
 	var medicationOrderedXPath = xpath.Compile("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")
-	rawMedicationOrdereds := ExtractSection(patientElement, medicationOrderedXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.17")
+	rawMedicationOrdereds := ExtractSection(patientElement, medicationOrderedXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.17", "ordered")
 	for i := range rawMedicationOrdereds {
 		patient.Medications = append(patient.Medications, rawMedicationOrdereds[i].(models.Medication))
 	}
 
 	//discharge medication active
 	var medicationDischargeActiveXPath = xpath.Compile("./cda:entry/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")
-	rawMedicationDischargeActives := ExtractSection(patientElement, medicationDischargeActiveXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.199")
+	rawMedicationDischargeActives := ExtractSection(patientElement, medicationDischargeActiveXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.199", "discharge")
 	for i := range rawMedicationDischargeActives {
 		patient.Medications = append(patient.Medications, rawMedicationDischargeActives[i].(models.Medication))
 	}
 
 	// medication intolerance
 	var medicationIntoleranceXPath = xpath.Compile("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")
-	rawMedicationIntolerances := ExtractSection(patientElement, medicationIntoleranceXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.67")
+	rawMedicationIntolerances := ExtractSection(patientElement, medicationIntoleranceXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.67", "")
 	for i := range rawMedicationIntolerances {
 		patient.Allergies = append(patient.Allergies, rawMedicationIntolerances[i].(models.Allergy))
 	}
 
 	// medication adverse event
 	var medicationAdverseEventXPath = xpath.Compile("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")
-	rawMedicationAdverseEvents := ExtractSection(patientElement, medicationAdverseEventXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.7")
+	rawMedicationAdverseEvents := ExtractSection(patientElement, medicationAdverseEventXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.7", "")
 	for i := range rawMedicationAdverseEvents {
 		patient.Allergies = append(patient.Allergies, rawMedicationAdverseEvents[i].(models.Allergy))
 	}
 
 	// medication allergy
 	var medicationAllergyXPath = xpath.Compile("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")
-	rawMedicationAllergies := ExtractSection(patientElement, medicationAllergyXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.1")
+	rawMedicationAllergies := ExtractSection(patientElement, medicationAllergyXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.1", "")
 	for i := range rawMedicationAllergies {
 		patient.Allergies = append(patient.Allergies, rawMedicationAllergies[i].(models.Allergy))
 	}
 
 	// procedure intolerance (such as flu shot intolerance)
 	var procedureIntoleranceXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.62']/cda:entryRelationship/cda:procedure[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.64']")
-	rawProcedureIntolerances := ExtractSection(patientElement, procedureIntoleranceXPath, ProcedureIntoleranceExtractor, "2.16.840.1.113883.3.560.1.61")
+	rawProcedureIntolerances := ExtractSection(patientElement, procedureIntoleranceXPath, ProcedureIntoleranceExtractor, "2.16.840.1.113883.3.560.1.61", "")
 	for i := range rawProcedureIntolerances {
 		patient.Allergies = append(patient.Allergies, rawProcedureIntolerances[i].(models.Allergy))
 	}
 
 	// Gestational Age (technically a condition)
 	var gestationalAgeXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.101']")
-	rawGestationalAges := ExtractSection(patientElement, gestationalAgeXPath, GestationalAgeExtractor, "2.16.840.1.113883.3.560.1.1001")
+	rawGestationalAges := ExtractSection(patientElement, gestationalAgeXPath, GestationalAgeExtractor, "2.16.840.1.113883.3.560.1.1001", "")
 	for i := range rawGestationalAges {
 		patient.Conditions = append(patient.Conditions, rawGestationalAges[i].(models.Condition))
 	}
 
 	// Communication: patient to provider
 	var communicationPatientToProviderXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']")
-	rawCommunicationsPatientToProvider := ExtractSection(patientElement, communicationPatientToProviderXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.30")
+	rawCommunicationsPatientToProvider := ExtractSection(patientElement, communicationPatientToProviderXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.30", "")
 	for i := range rawCommunicationsPatientToProvider {
 		patient.Communications = append(patient.Communications, rawCommunicationsPatientToProvider[i].(models.Communication))
 	}
 
 	// Communication: provider to provider
 	var communicationProviderToProviderXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']")
-	rawCommunicationsProviderToProvider := ExtractSection(patientElement, communicationProviderToProviderXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.129")
+	rawCommunicationsProviderToProvider := ExtractSection(patientElement, communicationProviderToProviderXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.129", "")
 	for i := range rawCommunicationsProviderToProvider {
 		patient.Communications = append(patient.Communications, rawCommunicationsProviderToProvider[i].(models.Communication))
 	}
 
 	// Communication: provider to patient: not done
 	var communicationProviderToPatientXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']")
-	rawCommunicationsProviderToPatient := ExtractSection(patientElement, communicationProviderToPatientXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.31")
+	rawCommunicationsProviderToPatient := ExtractSection(patientElement, communicationProviderToPatientXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.31", "")
 	for i := range rawCommunicationsProviderToPatient {
 		patient.Communications = append(patient.Communications, rawCommunicationsProviderToPatient[i].(models.Communication))
 	}
 
 	// ECOG Status
 	var ecogStatusXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.103']")
-	rawEcogStatuses := ExtractSection(patientElement, ecogStatusXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.1001")
+	rawEcogStatuses := ExtractSection(patientElement, ecogStatusXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.1001", "")
 	for i := range rawEcogStatuses {
 		patient.Conditions = append(patient.Conditions, rawEcogStatuses[i].(models.Condition))
 	}
 
 	// Symptom, active
 	var symptomActiveXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.76']")
-	rawActiveSymptoms := ExtractSection(patientElement, symptomActiveXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.69")
+	rawActiveSymptoms := ExtractSection(patientElement, symptomActiveXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.69", "active")
 	for i := range rawActiveSymptoms {
 		patient.Conditions = append(patient.Conditions, rawActiveSymptoms[i].(models.Condition))
 	}
 
 	// Diagnosis, Resolved
 	var diagonsisResolvedXPath = xpath.Compile("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.14']")
-	rawDiagnosesResolved := ExtractSection(patientElement, diagonsisResolvedXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.24")
+	rawDiagnosesResolved := ExtractSection(patientElement, diagonsisResolvedXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.24", "resolved")
 	for i := range rawDiagnosesResolved {
 		patient.Conditions = append(patient.Conditions, rawDiagnosesResolved[i].(models.Condition))
 	}
 
 	// Lab Test, Performed
 	var labResultPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']")
-	rawLabResults = ExtractSection(patientElement, labResultPerformedXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.5")
+	rawLabResults = ExtractSection(patientElement, labResultPerformedXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.5", "performed")
 	for i := range rawLabResults {
 		patient.LabResults = append(patient.LabResults, rawLabResults[i].(models.LabResult))
 	}
 
 	// Intervention, Result
 	var interventionResultXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")
-	rawInterventionResults := ExtractSection(patientElement, interventionResultXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.47")
+	rawInterventionResults := ExtractSection(patientElement, interventionResultXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.47", "")
 	for i := range rawInterventionResults {
 		patient.LabResults = append(patient.LabResults, rawInterventionResults[i].(models.LabResult))
 	}
 
 	// Physical Exam Finding
 	var physicalExamFindingXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.57']")
-	rawPhysicalExams := ExtractSection(patientElement, physicalExamFindingXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.18")
+	rawPhysicalExams := ExtractSection(patientElement, physicalExamFindingXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.18", "")
 	for i := range rawPhysicalExams {
 		patient.LabResults = append(patient.LabResults, rawPhysicalExams[i].(models.LabResult))
 	}
 
 	// Functional Status, Result
 	var functionalStatusResultXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.28']")
-	rawFunctionalStatuses := ExtractSection(patientElement, functionalStatusResultXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.88")
+	rawFunctionalStatuses := ExtractSection(patientElement, functionalStatusResultXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.88", "")
 	for i := range rawFunctionalStatuses {
 		patient.LabResults = append(patient.LabResults, rawFunctionalStatuses[i].(models.LabResult))
 	}
 
 	// Functional Status, Performed
 	var functionalStatusPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.26']")
-	rawFunctionalStatuses = ExtractSection(patientElement, functionalStatusPerformedXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.85")
+	rawFunctionalStatuses = ExtractSection(patientElement, functionalStatusPerformedXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.85", "")
 	for i := range rawFunctionalStatuses {
 		patient.LabResults = append(patient.LabResults, rawFunctionalStatuses[i].(models.LabResult))
 	}
 
 	//Medical Equipment Applied
 	var medEquipAppliedXPath = xpath.Compile("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']")
-	rawMedEquipApplied := ExtractSection(patientElement, medEquipAppliedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.110")
+	rawMedEquipApplied := ExtractSection(patientElement, medEquipAppliedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.110", "applied")
 	patient.MedicalEquipment = make([]models.MedicalEquipment, len(rawMedEquipApplied))
 	for i := range rawMedEquipApplied {
 		patient.MedicalEquipment[i] = rawMedEquipApplied[i].(models.MedicalEquipment)
@@ -268,84 +268,84 @@ func Read_patient(path string) string {
 
 	//Medical Equipment Not Ordered
 	var medEquipNotOrderedXPath = xpath.Compile("//cda:act[cda:code/@code = 'SPLY']")
-	rawMedEquipNotOrdered := ExtractSection(patientElement, medEquipNotOrderedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.137")
+	rawMedEquipNotOrdered := ExtractSection(patientElement, medEquipNotOrderedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.137", "")
 	for i := range rawMedEquipNotOrdered {
 		patient.MedicalEquipment = append(patient.MedicalEquipment, rawMedEquipNotOrdered[i].(models.MedicalEquipment))
 	}
 
 	// procedure performed
 	var procedurePerformedXPath = xpath.Compile("//cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']")
-	rawProcedurePerformed := ExtractSection(patientElement, procedurePerformedXPath, ProcedurePerformedExtractor, "2.16.840.1.113883.3.560.1.6")
+	rawProcedurePerformed := ExtractSection(patientElement, procedurePerformedXPath, ProcedurePerformedExtractor, "2.16.840.1.113883.3.560.1.6", "")
 	for i := range rawProcedurePerformed {
 		patient.Procedures = append(patient.Procedures, rawProcedurePerformed[i].(models.Procedure))
 	}
 
 	// Physical Exam, Performed
 	var physicalExamPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']")
-	rawPhysicalExamPerformed := ExtractSection(patientElement, physicalExamPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.57")
+	rawPhysicalExamPerformed := ExtractSection(patientElement, physicalExamPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.57", "performed")
 	for i := range rawPhysicalExamPerformed {
 		patient.Procedures = append(patient.Procedures, rawPhysicalExamPerformed[i].(models.Procedure))
 	}
 
 	// Intervention, Order
 	var interventionOrderXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']")
-	rawInterventionOrder := ExtractSection(patientElement, interventionOrderXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.45")
+	rawInterventionOrder := ExtractSection(patientElement, interventionOrderXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.45", "ordered")
 	for i := range rawInterventionOrder {
 		patient.Procedures = append(patient.Procedures, rawInterventionOrder[i].(models.Procedure))
 	}
 
 	// Intervention, Performed
 	var interventionPerformedXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']")
-	rawInterventionPerformed := ExtractSection(patientElement, interventionPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.46")
+	rawInterventionPerformed := ExtractSection(patientElement, interventionPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.46", "performed")
 	for i := range rawInterventionPerformed {
 		patient.Procedures = append(patient.Procedures, rawInterventionPerformed[i].(models.Procedure))
 	}
 
 	// Intervention, Results (procedure). this is different from Intervention, Performed (results)
 	var procedureInterventionResultXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")
-	rawProcedureInterventionResults := ExtractSection(patientElement, procedureInterventionResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.47")
+	rawProcedureInterventionResults := ExtractSection(patientElement, procedureInterventionResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.47", "")
 	for i := range rawProcedureInterventionResults {
 		patient.Procedures = append(patient.Procedures, rawProcedureInterventionResults[i].(models.Procedure))
 	}
 
 	// Procedure, Order
 	var procedureOrderXPath = xpath.Compile("//cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.63']")
-	rawProcedureOrders := ExtractSection(patientElement, procedureOrderXPath, ProcedureOrderExtractor, "2.16.840.1.113883.3.560.1.62")
+	rawProcedureOrders := ExtractSection(patientElement, procedureOrderXPath, ProcedureOrderExtractor, "2.16.840.1.113883.3.560.1.62", "ordered")
 	for i := range rawProcedureOrders {
 		patient.Procedures = append(patient.Procedures, rawProcedureOrders[i].(models.Procedure))
 	}
 
 	// Procedure, Result
 	var procedureResultXPath = xpath.Compile("//cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']")
-	rawProcedureResults := ExtractSection(patientElement, procedureResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.63")
+	rawProcedureResults := ExtractSection(patientElement, procedureResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.63", "")
 	for i := range rawProcedureResults {
 		patient.Procedures = append(patient.Procedures, rawProcedureResults[i].(models.Procedure))
 	}
 
 	// Risk Category Assessment
 	var riskCategoryAssessmentXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']")
-	rawRiskCategoryAssessments := ExtractSection(patientElement, riskCategoryAssessmentXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.21")
+	rawRiskCategoryAssessments := ExtractSection(patientElement, riskCategoryAssessmentXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.21", "")
 	for i := range rawRiskCategoryAssessments {
 		patient.Procedures = append(patient.Procedures, rawRiskCategoryAssessments[i].(models.Procedure))
 	}
 
 	// Diagnostic Study, not Performed
 	var diagnosticStudyNotPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']")
-	rawDiagnosticStudyNotPerformed := ExtractSection(patientElement, diagnosticStudyNotPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.103")
+	rawDiagnosticStudyNotPerformed := ExtractSection(patientElement, diagnosticStudyNotPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.103", "performed")
 	for i := range rawDiagnosticStudyNotPerformed {
 		patient.Procedures = append(patient.Procedures, rawDiagnosticStudyNotPerformed[i].(models.Procedure))
 	}
 
 	// Diagnostic Study, Result
 	var diagnosticStudyResultXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']")
-	rawDiagnosticStudyResults := ExtractSection(patientElement, diagnosticStudyResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.11")
+	rawDiagnosticStudyResults := ExtractSection(patientElement, diagnosticStudyResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.11", "")
 	for i := range rawDiagnosticStudyResults {
 		patient.Procedures = append(patient.Procedures, rawDiagnosticStudyResults[i].(models.Procedure))
 	}
 
 	// Care Goal
 	var careGoalXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']")
-	rawCareGoals := ExtractSection(patientElement, careGoalXPath, CareGoalExtractor, "2.16.840.1.113883.3.560.1.9")
+	rawCareGoals := ExtractSection(patientElement, careGoalXPath, CareGoalExtractor, "2.16.840.1.113883.3.560.1.9", "")
 	patient.CareGoals = make([]models.CareGoal, len(rawCareGoals))
 	for i := range rawCareGoals {
 		patient.CareGoals[i] = rawCareGoals[i].(models.CareGoal)
@@ -353,14 +353,14 @@ func Read_patient(path string) string {
 
 	// Patient Characteristic Clinical Trial Participant
 	var clinicalTrialParticipantXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.51']")
-	rawClinicalTrialParticipants := ExtractSection(patientElement, clinicalTrialParticipantXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.401")
+	rawClinicalTrialParticipants := ExtractSection(patientElement, clinicalTrialParticipantXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.401", "")
 	for i := range rawClinicalTrialParticipants {
 		patient.Conditions = append(patient.Conditions, rawClinicalTrialParticipants[i].(models.Condition))
 	}
 
 	// Patient Characteristic Expired
 	var patientExpiredXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")
-	rawPatientExpireds := ExtractSection(patientElement, patientExpiredXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.404")
+	rawPatientExpireds := ExtractSection(patientElement, patientExpiredXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.404", "")
 	for i := range rawPatientExpireds {
 		patient.Conditions = append(patient.Conditions, rawPatientExpireds[i].(models.Condition))
 	}
@@ -377,20 +377,20 @@ func Read_patient(path string) string {
 
 }
 
-func ExtractSection(xmlNode xml.Node, sectionXpath *xpath.Expression, extractor EntryExtractor, oid string) []interface{} {
+func ExtractSection(xmlNode xml.Node, sectionXpath *xpath.Expression, extractor EntryExtractor, oid string, status string) []interface{} {
 	sectionElements, err := xmlNode.Search(sectionXpath)
 	util.CheckErr(err)
 
 	entries := make([]interface{}, len(sectionElements))
 	for i, entryElement := range sectionElements {
-		entries[i] = ExtractEntry(entryElement, oid, extractor)
+		entries[i] = ExtractEntry(entryElement, oid, extractor, status)
 	}
 	return entries
 }
 
 type EntryExtractor func(*models.Entry, xml.Node) interface{}
 
-func ExtractEntry(entryElement xml.Node, oid string, extractor EntryExtractor) interface{} {
+func ExtractEntry(entryElement xml.Node, oid string, extractor EntryExtractor, status string) interface{} {
 	var entry models.Entry
 
 	//extract cda identifier
@@ -410,6 +410,9 @@ func ExtractEntry(entryElement xml.Node, oid string, extractor EntryExtractor) i
 
 	//create code map
 	entry.Codes = map[string][]string{}
+
+	// create status code and set status code from status
+	set_status_code(&entry, status)
 
 	fullEntry := extractor(&entry, entryElement)
 	return fullEntry
@@ -597,6 +600,24 @@ func set_patient_expired(patient *models.Record, xmlNode xml.Node) {
 			if value := deathDateElement.Attribute("value"); value != nil {
 				patient.DeathDate = TimestampToSeconds(value.String())
 			}
+		}
+	}
+}
+
+// create status code. then set status code from status if necessary
+func set_status_code(entry *models.Entry, status string) {
+	entry.StatusCode = map[string][]string{}
+	if status != "" { // only set a status code if status is not empty
+		switch status {
+		case "active":
+			entry.StatusCode["SNOMED-CT"] = []string{"55561003"}
+			entry.StatusCode["HL7 ActStatus"] = []string{"active"}
+		case "inactive":
+			entry.StatusCode["SNOMED-CT"] = []string{"73425007"}
+		case "resolved":
+			entry.StatusCode["SNOMED-CT"] = []string{"413322009"}
+		default:
+			entry.StatusCode["HL7 ActStatus"] = []string{status}
 		}
 	}
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -111,7 +111,7 @@ func Read_patient(path string) string {
 	}
 
 	//medication active
-	var medicationActiveXPath = xpath.Compile("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")
+	var medicationActiveXPath = xpath.Compile("//cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")
 	rawMedicationActives := ExtractSection(patientElement, medicationActiveXPath, MedicationActiveExtractor, "2.16.840.1.113883.3.560.1.13", "active")
 	patient.Medications = make([]models.Medication, len(rawMedicationActives))
 	for i := range rawMedicationActives {
@@ -119,49 +119,49 @@ func Read_patient(path string) string {
 	}
 
 	//medication dispensed
-	var medicationDispensedXPath = xpath.Compile("./cda:entry/cda:supply[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.45']")
+	var medicationDispensedXPath = xpath.Compile("//cda:entry/cda:supply[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.45']")
 	rawMedicationDispenseds := ExtractSection(patientElement, medicationDispensedXPath, MedicationDispensedExtractor, "2.16.840.1.113883.3.560.1.8", "dispensed")
 	for i := range rawMedicationDispenseds {
 		patient.Medications = append(patient.Medications, rawMedicationDispenseds[i].(models.Medication))
 	}
 
 	//medication administered
-	var medicationAdministeredXPath = xpath.Compile("./cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")
+	var medicationAdministeredXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")
 	rawMedicationAdministereds := ExtractSection(patientElement, medicationAdministeredXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.14", "administered")
 	for i := range rawMedicationAdministereds {
 		patient.Medications = append(patient.Medications, rawMedicationAdministereds[i].(models.Medication))
 	}
 
 	//medication ordered
-	var medicationOrderedXPath = xpath.Compile("./cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")
+	var medicationOrderedXPath = xpath.Compile("//cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")
 	rawMedicationOrdereds := ExtractSection(patientElement, medicationOrderedXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.17", "ordered")
 	for i := range rawMedicationOrdereds {
 		patient.Medications = append(patient.Medications, rawMedicationOrdereds[i].(models.Medication))
 	}
 
 	//discharge medication active
-	var medicationDischargeActiveXPath = xpath.Compile("./cda:entry/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")
+	var medicationDischargeActiveXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")
 	rawMedicationDischargeActives := ExtractSection(patientElement, medicationDischargeActiveXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.199", "discharge")
 	for i := range rawMedicationDischargeActives {
 		patient.Medications = append(patient.Medications, rawMedicationDischargeActives[i].(models.Medication))
 	}
 
 	// medication intolerance
-	var medicationIntoleranceXPath = xpath.Compile("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")
+	var medicationIntoleranceXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")
 	rawMedicationIntolerances := ExtractSection(patientElement, medicationIntoleranceXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.67", "")
 	for i := range rawMedicationIntolerances {
 		patient.Allergies = append(patient.Allergies, rawMedicationIntolerances[i].(models.Allergy))
 	}
 
 	// medication adverse event
-	var medicationAdverseEventXPath = xpath.Compile("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")
+	var medicationAdverseEventXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")
 	rawMedicationAdverseEvents := ExtractSection(patientElement, medicationAdverseEventXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.7", "")
 	for i := range rawMedicationAdverseEvents {
 		patient.Allergies = append(patient.Allergies, rawMedicationAdverseEvents[i].(models.Allergy))
 	}
 
 	// medication allergy
-	var medicationAllergyXPath = xpath.Compile("./cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")
+	var medicationAllergyXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")
 	rawMedicationAllergies := ExtractSection(patientElement, medicationAllergyXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.1", "")
 	for i := range rawMedicationAllergies {
 		patient.Allergies = append(patient.Allergies, rawMedicationAllergies[i].(models.Allergy))

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -262,7 +262,7 @@ func (i *ImporterSuite) TestMedicationActive(c *C) {
 	}
 
 	medicationActive := i.patient.Medications[0]
-	c.Assert(len(i.patient.Medications), Equals, 1)
+	c.Assert(len(i.patient.Medications), Equals, 2) // there is a second medication active for medication discharge active
 	c.Assert(medicationActive.ID.Root, Equals, "c0ea7bf3-50e7-4e7a-83a3-e5a9ccbb8541")
 	c.Assert(medicationActive.Codes["RxNorm"][0], Equals, "105152")
 	c.Assert(medicationActive.AdministrationTiming.InstitutionSpecified, Equals, true)
@@ -302,6 +302,139 @@ func (i *ImporterSuite) TestMedicationDispensed(c *C) {
 	c.Assert(medicationDispensed.StartTime, Equals, int64(822072083))
 	c.Assert(medicationDispensed.EndTime, Equals, int64(822089605))
 	c.Assert(medicationDispensed.StatusCode["HL7 ActStatus"][0], Equals, "dispensed")
+}
+
+func (i *ImporterSuite) TestMedicationAdministered(c *C) {
+	var medicationAdministeredXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.42']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.22.4.16']")
+	rawMedicationAdministereds := ExtractSection(i.patientElement, medicationAdministeredXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.14", "administered")
+	i.patient.Medications = make([]models.Medication, len(rawMedicationAdministereds))
+	for j := range rawMedicationAdministereds {
+		i.patient.Medications[j] = rawMedicationAdministereds[j].(models.Medication)
+	}
+
+	medicationAdministered := i.patient.Medications[0]
+	c.Assert(len(i.patient.Medications), Equals, 1)
+	c.Assert(medicationAdministered.ID.Root, Equals, "278dade0-4307-0130-0add-680688cbd736")
+	c.Assert(medicationAdministered.Oid, Equals, "2.16.840.1.113883.3.560.1.14")
+	c.Assert(medicationAdministered.Codes["CVX"][0], Equals, "33")
+	c.Assert(medicationAdministered.StartTime, Equals, int64(1165177036))
+	c.Assert(medicationAdministered.EndTime, Equals, int64(1165217102))
+	c.Assert(medicationAdministered.StatusCode["HL7 ActStatus"][0], Equals, "administered")
+}
+
+func (i *ImporterSuite) TestMedicationOrdered(c *C) {
+	var medicationOrderedXPath = xpath.Compile("//cda:entry/cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.47']")
+	rawMedicationOrdereds := ExtractSection(i.patientElement, medicationOrderedXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.17", "ordered")
+	i.patient.Medications = make([]models.Medication, len(rawMedicationOrdereds))
+	for j := range rawMedicationOrdereds {
+		i.patient.Medications[j] = rawMedicationOrdereds[j].(models.Medication)
+	}
+
+	medicationOrdered := i.patient.Medications[0]
+	c.Assert(len(i.patient.Medications), Equals, 1)
+	c.Assert(medicationOrdered.ID.Root, Equals, "50f84c1a7042f987750001d2")
+	c.Assert(medicationOrdered.Oid, Equals, "2.16.840.1.113883.3.560.1.17")
+	c.Assert(medicationOrdered.Codes["RxNorm"][0], Equals, "866439")
+	c.Assert(medicationOrdered.StartTime, Equals, int64(954202441))
+	c.Assert(medicationOrdered.EndTime, Equals, int64(954206964))
+	c.Assert(medicationOrdered.StatusCode["HL7 ActStatus"][0], Equals, "ordered")
+}
+
+func (i *ImporterSuite) TestMedicationDischargeActive(c *C) {
+	var medicationDischargeActiveXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.105']/cda:entryRelationship/cda:substanceAdministration[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.41']")
+	rawMedicationDischargeActives := ExtractSection(i.patientElement, medicationDischargeActiveXPath, MedicationExtractor, "2.16.840.1.113883.3.560.1.199", "discharge")
+	i.patient.Medications = make([]models.Medication, len(rawMedicationDischargeActives))
+	for j := range rawMedicationDischargeActives {
+		i.patient.Medications[j] = rawMedicationDischargeActives[j].(models.Medication)
+	}
+
+	medicationDischargeActive := i.patient.Medications[0]
+	c.Assert(len(i.patient.Medications), Equals, 1)
+	c.Assert(medicationDischargeActive.ID.Root, Equals, "21305e00-4308-0130-0ade-680688cbd736")
+	c.Assert(medicationDischargeActive.Oid, Equals, "2.16.840.1.113883.3.560.1.199")
+	c.Assert(medicationDischargeActive.Codes["RxNorm"][0], Equals, "994435")
+	c.Assert(medicationDischargeActive.StartTime, Equals, int64(1114859893))
+	c.Assert(medicationDischargeActive.EndTime, Equals, int64(1114914106))
+	c.Assert(medicationDischargeActive.StatusCode["HL7 ActStatus"][0], Equals, "discharge")
+}
+
+func (i *ImporterSuite) TestMedicationIntolerance(c *C) {
+	var medicationIntoleranceXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.46']")
+	rawMedicationIntolerances := ExtractSection(i.patientElement, medicationIntoleranceXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.67", "")
+	i.patient.Allergies = make([]models.Allergy, len(rawMedicationIntolerances))
+	for j := range rawMedicationIntolerances {
+		i.patient.Allergies[j] = rawMedicationIntolerances[j].(models.Allergy)
+	}
+
+	medicationIntolerance := i.patient.Allergies[0]
+	c.Assert(len(i.patient.Allergies), Equals, 1)
+	c.Assert(medicationIntolerance.ID.Root, Equals, "50f84c1a7042f987750001db")
+	c.Assert(medicationIntolerance.Oid, Equals, "2.16.840.1.113883.3.560.1.67")
+	c.Assert(medicationIntolerance.Codes["RxNorm"][0], Equals, "998695")
+	c.Assert(medicationIntolerance.StartTime, Equals, int64(1165177036))
+}
+
+func (i *ImporterSuite) TestMedicationAllergy(c *C) {
+	var medicationAllergyXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.44']")
+	rawMedicationAllergies := ExtractSection(i.patientElement, medicationAllergyXPath, AllergyExtractor, "2.16.840.1.113883.3.560.1.1", "")
+	i.patient.Allergies = make([]models.Allergy, len(rawMedicationAllergies))
+	for j := range rawMedicationAllergies {
+		i.patient.Allergies[j] = rawMedicationAllergies[j].(models.Allergy)
+	}
+
+	medicationAllergy := i.patient.Allergies[0]
+	c.Assert(len(i.patient.Allergies), Equals, 1)
+	c.Assert(medicationAllergy.ID.Root, Equals, "50f84db97042f9366f00000e")
+	c.Assert(medicationAllergy.Oid, Equals, "2.16.840.1.113883.3.560.1.1")
+	c.Assert(medicationAllergy.Codes["RxNorm"][0], Equals, "996994")
+	c.Assert(medicationAllergy.StartTime, Equals, int64(303055256))
+}
+
+func (i *ImporterSuite) TestMedEquipNotOrdered(c *C) {
+	var medEquipNotOrderedXPath = xpath.Compile("//cda:act[cda:code/@code = 'SPLY']")
+	rawMedEquipNotOrdered := ExtractSection(i.patientElement, medEquipNotOrderedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.137", "")
+	i.patient.MedicalEquipment = make([]models.MedicalEquipment, len(rawMedEquipNotOrdered))
+	for j := range rawMedEquipNotOrdered {
+		i.patient.MedicalEquipment[j] = rawMedEquipNotOrdered[j].(models.MedicalEquipment)
+	}
+
+	medEquipNotOrdered := i.patient.MedicalEquipment[0]
+	c.Assert(len(i.patient.MedicalEquipment), Equals, 1)
+	c.Assert(medEquipNotOrdered.ID.Root, Equals, "1.3.6.1.4.1.115")
+	c.Assert(medEquipNotOrdered.Oid, Equals, "2.16.840.1.113883.3.560.1.137")
+	c.Assert(medEquipNotOrdered.Codes["ICD-9-CM"][0], Equals, "48.20")
+}
+
+func (i *ImporterSuite) TestCommunicationsProviderToProvider(c *C) {
+	var communicationProviderToProviderXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.4']")
+	rawCommunicationsProviderToProvider := ExtractSection(i.patientElement, communicationProviderToProviderXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.129", "")
+	i.patient.Communications = make([]models.Communication, len(rawCommunicationsProviderToProvider))
+	for j := range rawCommunicationsProviderToProvider {
+		i.patient.Communications[j] = rawCommunicationsProviderToProvider[j].(models.Communication)
+	}
+
+	communicationsProviderToProvider := i.patient.Communications[0]
+	c.Assert(len(i.patient.Communications), Equals, 1)
+	c.Assert(communicationsProviderToProvider.ID.Root, Equals, "50f84c1d7042f987750003bf")
+	c.Assert(communicationsProviderToProvider.Oid, Equals, "2.16.840.1.113883.3.560.1.129")
+	c.Assert(communicationsProviderToProvider.Codes["SNOMED-CT"][0], Equals, "371545006")
+	c.Assert(communicationsProviderToProvider.StartTime, Equals, int64(362499961))
+}
+
+func (i *ImporterSuite) TestCommunicationsProviderToPatient(c *C) {
+	var communicationProviderToPatientXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.3']")
+	rawCommunicationsProviderToPatient := ExtractSection(i.patientElement, communicationProviderToPatientXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.31", "")
+	i.patient.Communications = make([]models.Communication, len(rawCommunicationsProviderToPatient))
+	for j := range rawCommunicationsProviderToPatient {
+		i.patient.Communications[j] = rawCommunicationsProviderToPatient[j].(models.Communication)
+	}
+
+	communicationProviderToPatient := i.patient.Communications[0]
+	c.Assert(len(i.patient.Communications), Equals, 1)
+	c.Assert(communicationProviderToPatient.ID.Root, Equals, "50cf48409eae47465700008f")
+	c.Assert(communicationProviderToPatient.Oid, Equals, "2.16.840.1.113883.3.560.1.31")
+	c.Assert(communicationProviderToPatient.Codes["LOINC"][0], Equals, "69981-9")
+	c.Assert(communicationProviderToPatient.StartTime, Equals, int64(1275775200))
 }
 
 func (i *ImporterSuite) TestAllergy(c *C) {

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -52,7 +52,7 @@ func (i *ImporterSuite) TestExtractDemograpics(c *C) {
 
 func (i *ImporterSuite) TestExtractEncountersPerformed(c *C) {
 	var encounterXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.23']")
-	rawEncounters := ExtractSection(i.patientElement, encounterXPath, EncounterPerformedExtractor, "2.16.840.1.113883.3.560.1.79")
+	rawEncounters := ExtractSection(i.patientElement, encounterXPath, EncounterPerformedExtractor, "2.16.840.1.113883.3.560.1.79", "performed")
 	i.patient.Encounters = make([]models.Encounter, len(rawEncounters))
 	for j := range rawEncounters {
 		i.patient.Encounters[j] = rawEncounters[j].(models.Encounter)
@@ -66,11 +66,12 @@ func (i *ImporterSuite) TestExtractEncountersPerformed(c *C) {
 	c.Assert(encounter.Codes["CPT"][0], Equals, "99201")
 	c.Assert(encounter.StartTime, Equals, int64(1288612800))
 	c.Assert(encounter.EndTime, Equals, int64(1288616400))
+	c.Assert(encounter.StatusCode["HL7 ActStatus"][0], Equals, "performed")
 }
 
 func (i *ImporterSuite) TestExtractEncounterOrdered(c *C) {
 	var encounterOrderXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.22']")
-	rawEncounterOrders := ExtractSection(i.patientElement, encounterOrderXPath, EncounterOrderExtractor, "2.16.840.1.113883.3.560.1.83")
+	rawEncounterOrders := ExtractSection(i.patientElement, encounterOrderXPath, EncounterOrderExtractor, "2.16.840.1.113883.3.560.1.83", "ordered")
 	i.patient.Encounters = make([]models.Encounter, len(rawEncounterOrders))
 	for j := range rawEncounterOrders {
 		i.patient.Encounters[j] = rawEncounterOrders[j].(models.Encounter)
@@ -87,11 +88,12 @@ func (i *ImporterSuite) TestExtractEncounterOrdered(c *C) {
 	c.Assert(encounter.Codes["ICD-10-PCS"][0], Equals, "GZHZZZZ")
 	c.Assert(encounter.StartTime, Equals, int64(1135608034))
 	c.Assert(encounter.EndTime, Equals, int64(1135608034))
+	c.Assert(encounter.StatusCode["HL7 ActStatus"][0], Equals, "ordered")
 }
 
 func (i *ImporterSuite) TestExtractDiagnosesActive(c *C) {
 	var diagnosisXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.11']")
-	rawDiagnoses := ExtractSection(i.patientElement, diagnosisXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.2")
+	rawDiagnoses := ExtractSection(i.patientElement, diagnosisXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.2", "active")
 	i.patient.Conditions = make([]models.Condition, len(rawDiagnoses))
 	for j := range rawDiagnoses {
 		i.patient.Conditions[j] = rawDiagnoses[j].(models.Condition)
@@ -106,6 +108,8 @@ func (i *ImporterSuite) TestExtractDiagnosesActive(c *C) {
 	c.Assert(firstDiagnosis.StartTime, Equals, int64(1332775800))
 	c.Assert(firstDiagnosis.EndTime, Equals, int64(0))
 	c.Assert(firstDiagnosis.Severity["SNOMED-CT"][0], Equals, "55561003")
+	c.Assert(firstDiagnosis.StatusCode["SNOMED-CT"][0], Equals, "55561003")
+	c.Assert(firstDiagnosis.StatusCode["HL7 ActStatus"][0], Equals, "active")
 
 	secondDiagnosis := i.patient.Conditions[1]
 	c.Assert(secondDiagnosis.ID.Root, Equals, "1.3.6.1.4.1.115")
@@ -114,6 +118,8 @@ func (i *ImporterSuite) TestExtractDiagnosesActive(c *C) {
 	c.Assert(secondDiagnosis.Description, Equals, "Diagnosis, Active: Pregnancy Dx")
 	c.Assert(secondDiagnosis.StartTime, Equals, int64(1362150000))
 	c.Assert(secondDiagnosis.EndTime, Equals, int64(1382284800))
+	c.Assert(secondDiagnosis.StatusCode["SNOMED-CT"][0], Equals, "55561003")
+	c.Assert(secondDiagnosis.StatusCode["HL7 ActStatus"][0], Equals, "active")
 
 	thirdDiagnosis := i.patient.Conditions[2]
 	c.Assert(thirdDiagnosis.ID.Root, Equals, "1.3.6.1.4.1.115")
@@ -122,11 +128,13 @@ func (i *ImporterSuite) TestExtractDiagnosesActive(c *C) {
 	c.Assert(thirdDiagnosis.Description, Equals, "Diagnosis, Active: Diabetes")
 	c.Assert(thirdDiagnosis.StartTime, Equals, int64(1361890800))
 	c.Assert(thirdDiagnosis.EndTime, Equals, int64(0))
+	c.Assert(thirdDiagnosis.StatusCode["SNOMED-CT"][0], Equals, "55561003")
+	c.Assert(thirdDiagnosis.StatusCode["HL7 ActStatus"][0], Equals, "active")
 }
 
 func (i *ImporterSuite) TestExtractDiagnosesInactive(c *C) {
 	var diagnosisInactiveXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.13']")
-	rawDiagnosesInactive := ExtractSection(i.patientElement, diagnosisInactiveXPath, DiagnosisInactiveExtractor, "2.16.840.1.113883.3.560.1.2")
+	rawDiagnosesInactive := ExtractSection(i.patientElement, diagnosisInactiveXPath, DiagnosisInactiveExtractor, "2.16.840.1.113883.3.560.1.23", "inactive")
 	i.patient.Conditions = make([]models.Condition, len(rawDiagnosesInactive))
 	for j := range rawDiagnosesInactive {
 		i.patient.Conditions[j] = rawDiagnosesInactive[j].(models.Condition)
@@ -140,11 +148,12 @@ func (i *ImporterSuite) TestExtractDiagnosesInactive(c *C) {
 	c.Assert(diagnosis.Codes["ICD-10-CM"][0], Equals, "Z22.51")
 	c.Assert(diagnosis.StartTime, Equals, int64(1092658739))
 	c.Assert(diagnosis.EndTime, Equals, int64(1092686969))
+	c.Assert(diagnosis.StatusCode["SNOMED-CT"][0], Equals, "73425007")
 }
 
 func (i *ImporterSuite) TestExtractLabResults(c *C) {
 	var labResultXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.40']")
-	rawLabResults := ExtractSection(i.patientElement, labResultXPath, LabResultExtractor, "2.16.840.1.113883.3.560.1.12")
+	rawLabResults := ExtractSection(i.patientElement, labResultXPath, LabResultExtractor, "2.16.840.1.113883.3.560.1.12", "")
 	i.patient.LabResults = make([]models.LabResult, len(rawLabResults))
 	for j := range rawLabResults {
 		i.patient.LabResults[j] = rawLabResults[j].(models.LabResult)
@@ -163,7 +172,7 @@ func (i *ImporterSuite) TestExtractLabResults(c *C) {
 
 func (i *ImporterSuite) TestExtractLabOrders(c *C) {
 	var labOrderXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.37']")
-	rawLabOrders := ExtractSection(i.patientElement, labOrderXPath, LabOrderExtractor, "")
+	rawLabOrders := ExtractSection(i.patientElement, labOrderXPath, LabOrderExtractor, "2.16.840.1.113883.3.560.1.50", "ordered")
 	i.patient.LabResults = make([]models.LabResult, len(rawLabOrders))
 	for j := range rawLabOrders {
 		i.patient.LabResults[j] = rawLabOrders[j].(models.LabResult)
@@ -172,13 +181,15 @@ func (i *ImporterSuite) TestExtractLabOrders(c *C) {
 	labOrder := i.patient.LabResults[0]
 	c.Assert(len(i.patient.LabResults), Equals, 1)
 	c.Assert(labOrder.ID.Root, Equals, "50f84c1d7042f9877500039e")
+	c.Assert(labOrder.Oid, Equals, "2.16.840.1.113883.3.560.1.50")
 	c.Assert(labOrder.Codes["SNOMED-CT"][0], Equals, "8879006")
 	c.Assert(labOrder.StartTime, Equals, int64(674670276))
+	c.Assert(labOrder.StatusCode["HL7 ActStatus"][0], Equals, "ordered")
 }
 
 func (i *ImporterSuite) TestExtractInsuranceProviders(c *C) {
 	var insuranceProviderXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.55']")
-	rawInsuranceProviders := ExtractSection(i.patientElement, insuranceProviderXPath, InsuranceProviderExtractor, "2.16.840.1.113883.3.560.1.405")
+	rawInsuranceProviders := ExtractSection(i.patientElement, insuranceProviderXPath, InsuranceProviderExtractor, "2.16.840.1.113883.3.560.1.405", "")
 	i.patient.InsuranceProviders = make([]models.InsuranceProvider, len(rawInsuranceProviders))
 	for j := range rawInsuranceProviders {
 		i.patient.InsuranceProviders[j] = rawInsuranceProviders[j].(models.InsuranceProvider)
@@ -193,7 +204,7 @@ func (i *ImporterSuite) TestExtractInsuranceProviders(c *C) {
 
 func (i *ImporterSuite) TestExtractDiagnosticStudyOrders(c *C) {
 	var diagnosticStudyOrderXPath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.17']")
-	rawDiagnosticStudyOrders := ExtractSection(i.patientElement, diagnosticStudyOrderXPath, DiagnosticStudyOrderExtractor, "2.16.840.1.113883.3.560.1.40")
+	rawDiagnosticStudyOrders := ExtractSection(i.patientElement, diagnosticStudyOrderXPath, DiagnosticStudyOrderExtractor, "2.16.840.1.113883.3.560.1.40", "ordered")
 	i.patient.Procedures = make([]models.Procedure, len(rawDiagnosticStudyOrders))
 	for j := range rawDiagnosticStudyOrders {
 		i.patient.Procedures[j] = rawDiagnosticStudyOrders[j].(models.Procedure)
@@ -205,11 +216,12 @@ func (i *ImporterSuite) TestExtractDiagnosticStudyOrders(c *C) {
 	c.Assert(diagnosticStudyOrder.Codes["LOINC"][0], Equals, "69399-4")
 	c.Assert(diagnosticStudyOrder.StartTime, Equals, int64(629709860)) // start and end time should be equal for diagnostic study orders
 	c.Assert(diagnosticStudyOrder.EndTime, Equals, int64(629709860))
+	c.Assert(diagnosticStudyOrder.StatusCode["HL7 ActStatus"][0], Equals, "ordered")
 }
 
 func (i *ImporterSuite) TestExtractTransferFrom(c *C) {
 	var transferFromXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.81']")
-	rawTransferFroms := ExtractSection(i.patientElement, transferFromXPath, TransferFromExtractor, "2.16.840.1.113883.3.560.1.71")
+	rawTransferFroms := ExtractSection(i.patientElement, transferFromXPath, TransferFromExtractor, "2.16.840.1.113883.3.560.1.71", "")
 	i.patient.Encounters = make([]models.Encounter, len(rawTransferFroms))
 	for j := range rawTransferFroms {
 		i.patient.Encounters[j] = rawTransferFroms[j].(models.Encounter)
@@ -226,7 +238,7 @@ func (i *ImporterSuite) TestExtractTransferFrom(c *C) {
 
 func (i *ImporterSuite) TestExtractTransferTo(c *C) {
 	var transferToXPath = xpath.Compile("//cda:encounter[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.82']")
-	rawTransferTos := ExtractSection(i.patientElement, transferToXPath, TransferToExtractor, "2.16.840.1.113883.3.560.1.72")
+	rawTransferTos := ExtractSection(i.patientElement, transferToXPath, TransferToExtractor, "2.16.840.1.113883.3.560.1.72", "")
 	i.patient.Encounters = make([]models.Encounter, len(rawTransferTos))
 	for j := range rawTransferTos {
 		i.patient.Encounters[j] = rawTransferTos[j].(models.Encounter)
@@ -243,7 +255,7 @@ func (i *ImporterSuite) TestExtractTransferTo(c *C) {
 
 func (i *ImporterSuite) TestMedicationActive(c *C) {
 	var medicationActiveXPath = xpath.Compile("//cda:substanceAdministration[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.41']")
-	rawMedicationActives := ExtractSection(i.patientElement, medicationActiveXPath, MedicationActiveExtractor, "2.16.840.1.113883.3.560.1.13")
+	rawMedicationActives := ExtractSection(i.patientElement, medicationActiveXPath, MedicationActiveExtractor, "2.16.840.1.113883.3.560.1.13", "active")
 	i.patient.Medications = make([]models.Medication, len(rawMedicationActives))
 	for j := range rawMedicationActives {
 		i.patient.Medications[j] = rawMedicationActives[j].(models.Medication)
@@ -270,12 +282,14 @@ func (i *ImporterSuite) TestMedicationActive(c *C) {
 	c.Assert(medicationActive.OrderInformation[0].QuantityOrdered.Value, Equals, int64(75))
 	c.Assert(medicationActive.OrderInformation[0].OrderNumber, Equals, "12345")
 	c.Assert(medicationActive.OrderInformation[0].OrderDate, Equals, int64(1092676026))
+	c.Assert(medicationActive.StatusCode["SNOMED-CT"][0], Equals, "55561003")
+	c.Assert(medicationActive.StatusCode["HL7 ActStatus"][0], Equals, "active")
 
 }
 
 func (i *ImporterSuite) TestMedicationDispensed(c *C) {
 	var medicationDispensedXPath = xpath.Compile("//cda:supply[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.45']")
-	rawMedicationDispenseds := ExtractSection(i.patientElement, medicationDispensedXPath, MedicationDispensedExtractor, "2.16.840.1.113883.3.560.1.8")
+	rawMedicationDispenseds := ExtractSection(i.patientElement, medicationDispensedXPath, MedicationDispensedExtractor, "2.16.840.1.113883.3.560.1.8", "dispensed")
 	i.patient.Medications = make([]models.Medication, len(rawMedicationDispenseds))
 	for j := range rawMedicationDispenseds {
 		i.patient.Medications[j] = rawMedicationDispenseds[j].(models.Medication)
@@ -287,11 +301,12 @@ func (i *ImporterSuite) TestMedicationDispensed(c *C) {
 	c.Assert(medicationDispensed.Codes["RxNorm"][0], Equals, "977869")
 	c.Assert(medicationDispensed.StartTime, Equals, int64(822072083))
 	c.Assert(medicationDispensed.EndTime, Equals, int64(822089605))
+	c.Assert(medicationDispensed.StatusCode["HL7 ActStatus"][0], Equals, "dispensed")
 }
 
 func (i *ImporterSuite) TestAllergy(c *C) {
 	var allergyXpath = xpath.Compile("//cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.43']")
-	rawAllergies := ExtractSection(i.patientElement, allergyXpath, AllergyExtractor, "2.16.840.1.113883.3.560.1.7")
+	rawAllergies := ExtractSection(i.patientElement, allergyXpath, AllergyExtractor, "2.16.840.1.113883.3.560.1.7", "")
 
 	i.patient.Allergies = make([]models.Allergy, len(rawAllergies))
 	for j := range rawAllergies {
@@ -310,7 +325,7 @@ func (i *ImporterSuite) TestAllergy(c *C) {
 
 func (i *ImporterSuite) TestProcedureIntolerance(c *C) {
 	var procedureIntoleranceXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.62']/cda:entryRelationship/cda:procedure[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.64']")
-	rawProcedureIntolerances := ExtractSection(i.patientElement, procedureIntoleranceXPath, ProcedureIntoleranceExtractor, "2.16.840.1.113883.3.560.1.61")
+	rawProcedureIntolerances := ExtractSection(i.patientElement, procedureIntoleranceXPath, ProcedureIntoleranceExtractor, "2.16.840.1.113883.3.560.1.61", "")
 
 	i.patient.Allergies = make([]models.Allergy, len(rawProcedureIntolerances))
 	for j := range rawProcedureIntolerances {
@@ -328,7 +343,7 @@ func (i *ImporterSuite) TestProcedureIntolerance(c *C) {
 
 func (i *ImporterSuite) TestGestationalAge(c *C) {
 	var gestationalAgeXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.101']")
-	rawGestationalAges := ExtractSection(i.patientElement, gestationalAgeXPath, GestationalAgeExtractor, "2.16.840.1.113883.3.560.1.1001")
+	rawGestationalAges := ExtractSection(i.patientElement, gestationalAgeXPath, GestationalAgeExtractor, "2.16.840.1.113883.3.560.1.1001", "")
 
 	i.patient.Conditions = make([]models.Condition, len(rawGestationalAges))
 	for j := range rawGestationalAges {
@@ -344,7 +359,7 @@ func (i *ImporterSuite) TestGestationalAge(c *C) {
 
 func (i *ImporterSuite) TestCommunication(c *C) {
 	var communicationXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.2']")
-	rawCommunications := ExtractSection(i.patientElement, communicationXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.30")
+	rawCommunications := ExtractSection(i.patientElement, communicationXPath, CommunicationExtractor, "2.16.840.1.113883.3.560.1.30", "")
 
 	i.patient.Communications = make([]models.Communication, len(rawCommunications))
 	for j := range rawCommunications {
@@ -366,7 +381,7 @@ func (i *ImporterSuite) TestCommunication(c *C) {
 
 func (i *ImporterSuite) TestEcogStatus(c *C) {
 	var ecogStatusXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.103']")
-	rawEcogStatuses := ExtractSection(i.patientElement, ecogStatusXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.1001")
+	rawEcogStatuses := ExtractSection(i.patientElement, ecogStatusXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.1001", "")
 	i.patient.Conditions = make([]models.Condition, len(rawEcogStatuses))
 	for j := range rawEcogStatuses {
 		i.patient.Conditions[j] = rawEcogStatuses[j].(models.Condition)
@@ -379,7 +394,7 @@ func (i *ImporterSuite) TestEcogStatus(c *C) {
 
 func (i *ImporterSuite) TestSymptomActive(c *C) {
 	var symptomActiveXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.76']")
-	rawActiveSymptoms := ExtractSection(i.patientElement, symptomActiveXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.69")
+	rawActiveSymptoms := ExtractSection(i.patientElement, symptomActiveXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.69", "active")
 	i.patient.Conditions = make([]models.Condition, len(rawActiveSymptoms))
 	for j := range rawActiveSymptoms {
 		i.patient.Conditions[j] = rawActiveSymptoms[j].(models.Condition)
@@ -390,11 +405,13 @@ func (i *ImporterSuite) TestSymptomActive(c *C) {
 	c.Assert(activeSymptom.EndTime, Equals, int64(729867188))
 	c.Assert(activeSymptom.ID.Root, Equals, "50f84dbb7042f9366f0001ac")
 	c.Assert(activeSymptom.Oid, Equals, "2.16.840.1.113883.3.560.1.69")
+	c.Assert(activeSymptom.StatusCode["SNOMED-CT"][0], Equals, "55561003")
+	c.Assert(activeSymptom.StatusCode["HL7 ActStatus"][0], Equals, "active")
 }
 
 func (i *ImporterSuite) TestDiagnosisResolved(c *C) {
 	var diagonsisResolvedXPath = xpath.Compile("//cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.14']")
-	rawDiagnosesResolved := ExtractSection(i.patientElement, diagonsisResolvedXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.24")
+	rawDiagnosesResolved := ExtractSection(i.patientElement, diagonsisResolvedXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.24", "resolved")
 	i.patient.Conditions = make([]models.Condition, len(rawDiagnosesResolved))
 	for j := range rawDiagnosesResolved {
 		i.patient.Conditions[j] = rawDiagnosesResolved[j].(models.Condition)
@@ -405,11 +422,12 @@ func (i *ImporterSuite) TestDiagnosisResolved(c *C) {
 	c.Assert(diagnosisResolved.Codes["SNOMED-CT"][0], Equals, "94643001")
 	c.Assert(diagnosisResolved.Codes["ICD-10-CM"][0], Equals, "C21.8")
 	c.Assert(diagnosisResolved.Codes["ICD-9-CM"][0], Equals, "197.5")
+	c.Assert(diagnosisResolved.StatusCode["SNOMED-CT"][0], Equals, "413322009")
 }
 
 func (i *ImporterSuite) TestLabResultPerformed(c *C) {
 	var labResultPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.38']")
-	rawLabResults := ExtractSection(i.patientElement, labResultPerformedXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.5")
+	rawLabResults := ExtractSection(i.patientElement, labResultPerformedXPath, ResultExtractor, "2.16.840.1.113883.3.560.1.5", "performed")
 	i.patient.LabResults = make([]models.LabResult, len(rawLabResults))
 	for j := range rawLabResults {
 		i.patient.LabResults[j] = rawLabResults[j].(models.LabResult)
@@ -421,11 +439,12 @@ func (i *ImporterSuite) TestLabResultPerformed(c *C) {
 	// c.Assert(labResult.Interpretation.Code, Equals, "N")
 	// c.Assert(labResult.Interpretation.CodeSystem, Equals, "HITSP C80 Observation Status")
 	c.Assert(labResult.ReferenceRange, Equals, "M 13-18 g/dl; F 12-16 g/dl")
+	c.Assert(labResult.StatusCode["HL7 ActStatus"][0], Equals, "performed")
 }
 
 func (i *ImporterSuite) TestMedicalEquipmentApplied(c *C) {
 	var medEquipAppliedXPath = xpath.Compile("//cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.7']")
-	rawMedEquipApplied := ExtractSection(i.patientElement, medEquipAppliedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.110")
+	rawMedEquipApplied := ExtractSection(i.patientElement, medEquipAppliedXPath, MedicalEquipmentExtractor, "2.16.840.1.113883.3.560.1.110", "applied")
 	i.patient.MedicalEquipment = make([]models.MedicalEquipment, len(rawMedEquipApplied))
 	for j := range rawMedEquipApplied {
 		i.patient.MedicalEquipment[j] = rawMedEquipApplied[j].(models.MedicalEquipment)
@@ -437,11 +456,12 @@ func (i *ImporterSuite) TestMedicalEquipmentApplied(c *C) {
 	c.Assert(medEquipApplied.AnatomicalStructure.Code, Equals, "thigh")
 	c.Assert(medEquipApplied.AnatomicalStructure.CodeSystem, Equals, "2.16.840.1.113883.6.96")
 	c.Assert(medEquipApplied.AnatomicalStructure.CodeSystemName, Equals, "SNOMED-CT")
+	c.Assert(medEquipApplied.StatusCode["HL7 ActStatus"][0], Equals, "applied")
 }
 
 func (i *ImporterSuite) TestExtractProcedurePerformed(c *C) {
 	var procedurePerformedXPath = xpath.Compile("//cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.64']")
-	rawProcedurePerformed := ExtractSection(i.patientElement, procedurePerformedXPath, ProcedurePerformedExtractor, "2.16.840.1.113883.3.560.1.6")
+	rawProcedurePerformed := ExtractSection(i.patientElement, procedurePerformedXPath, ProcedurePerformedExtractor, "2.16.840.1.113883.3.560.1.6", "")
 	i.patient.Procedures = make([]models.Procedure, len(rawProcedurePerformed))
 	for j := range rawProcedurePerformed {
 		i.patient.Procedures[j] = rawProcedurePerformed[j].(models.Procedure)
@@ -487,7 +507,7 @@ func (i *ImporterSuite) TestExtractProcedurePerformed(c *C) {
 
 func (i *ImporterSuite) TestExtractPhysicalExamPerformed(c *C) {
 	var physicalExamPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.59']")
-	rawPhysicalExamPerformed := ExtractSection(i.patientElement, physicalExamPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.57")
+	rawPhysicalExamPerformed := ExtractSection(i.patientElement, physicalExamPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.57", "performed")
 	i.patient.Procedures = make([]models.Procedure, len(rawPhysicalExamPerformed))
 	for j := range rawPhysicalExamPerformed {
 		i.patient.Procedures[j] = rawPhysicalExamPerformed[j].(models.Procedure)
@@ -502,11 +522,12 @@ func (i *ImporterSuite) TestExtractPhysicalExamPerformed(c *C) {
 	c.Assert(physicalExamPerformed.EndTime, Equals, int64(751060302))
 	c.Assert(physicalExamPerformed.NegationInd, Equals, true)
 	c.Assert(physicalExamPerformed.NegationReason, Equals, models.CodedConcept{})
+	c.Assert(physicalExamPerformed.StatusCode["HL7 ActStatus"][0], Equals, "performed")
 }
 
 func (i *ImporterSuite) TestExtractInterventionOrder(c *C) {
 	var interventionOrderXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.31']")
-	rawInterventionOrder := ExtractSection(i.patientElement, interventionOrderXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.45")
+	rawInterventionOrder := ExtractSection(i.patientElement, interventionOrderXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.45", "ordered")
 	i.patient.Procedures = make([]models.Procedure, len(rawInterventionOrder))
 	for j := range rawInterventionOrder {
 		i.patient.Procedures[j] = rawInterventionOrder[j].(models.Procedure)
@@ -521,11 +542,12 @@ func (i *ImporterSuite) TestExtractInterventionOrder(c *C) {
 	c.Assert(interventionOrder.Codes["ICD-10-CM"][0], Equals, "Z71.3")
 	c.Assert(interventionOrder.Codes["SNOMED-CT"][0], Equals, "304549008")
 	c.Assert(interventionOrder.StartTime, Equals, int64(1277424000))
+	c.Assert(interventionOrder.StatusCode["HL7 ActStatus"][0], Equals, "ordered")
 }
 
 func (i *ImporterSuite) TestExtractInterventionPerformed(c *C) {
 	var interventionPerformedXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.32']")
-	rawInterventionPerformed := ExtractSection(i.patientElement, interventionPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.46")
+	rawInterventionPerformed := ExtractSection(i.patientElement, interventionPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.46", "performed")
 	i.patient.Procedures = make([]models.Procedure, len(rawInterventionPerformed))
 	for j := range rawInterventionPerformed {
 		i.patient.Procedures[j] = rawInterventionPerformed[j].(models.Procedure)
@@ -538,11 +560,12 @@ func (i *ImporterSuite) TestExtractInterventionPerformed(c *C) {
 	c.Assert(interventionPerformed.Codes["SNOMED-CT"][0], Equals, "171207006")
 	c.Assert(interventionPerformed.StartTime, Equals, int64(1265371200))
 	c.Assert(interventionPerformed.EndTime, Equals, int64(1265371200))
+	c.Assert(interventionPerformed.StatusCode["HL7 ActStatus"][0], Equals, "performed")
 }
 
 func (i *ImporterSuite) TestExtractProcedureInterventionResults(c *C) {
 	var procedureInterventionResultXPath = xpath.Compile("//cda:entry/cda:act[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.34']")
-	rawProcedureInterventionResults := ExtractSection(i.patientElement, procedureInterventionResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.47")
+	rawProcedureInterventionResults := ExtractSection(i.patientElement, procedureInterventionResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.47", "")
 	i.patient.Procedures = make([]models.Procedure, len(rawProcedureInterventionResults))
 	for j := range rawProcedureInterventionResults {
 		i.patient.Procedures[j] = rawProcedureInterventionResults[j].(models.Procedure)
@@ -559,7 +582,7 @@ func (i *ImporterSuite) TestExtractProcedureInterventionResults(c *C) {
 
 func (i *ImporterSuite) TestExtractProcedureOrder(c *C) {
 	var procedureOrderXPath = xpath.Compile("//cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.63']")
-	rawProcedureOrders := ExtractSection(i.patientElement, procedureOrderXPath, ProcedureOrderExtractor, "2.16.840.1.113883.3.560.1.62")
+	rawProcedureOrders := ExtractSection(i.patientElement, procedureOrderXPath, ProcedureOrderExtractor, "2.16.840.1.113883.3.560.1.62", "ordered")
 	i.patient.Procedures = make([]models.Procedure, len(rawProcedureOrders))
 	for j := range rawProcedureOrders {
 		i.patient.Procedures[j] = rawProcedureOrders[j].(models.Procedure)
@@ -580,7 +603,7 @@ func (i *ImporterSuite) TestExtractProcedureOrder(c *C) {
 
 func (i *ImporterSuite) TestExtractProcedureResults(c *C) {
 	var procedureResultsXPath = xpath.Compile("//cda:entry/cda:procedure[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.66']")
-	rawProcedureResults := ExtractSection(i.patientElement, procedureResultsXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.63")
+	rawProcedureResults := ExtractSection(i.patientElement, procedureResultsXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.63", "")
 	i.patient.Procedures = make([]models.Procedure, len(rawProcedureResults))
 	for j := range rawProcedureResults {
 		i.patient.Procedures[j] = rawProcedureResults[j].(models.Procedure)
@@ -597,7 +620,7 @@ func (i *ImporterSuite) TestExtractProcedureResults(c *C) {
 
 func (i *ImporterSuite) TestExtractRiskCategoryAssessment(c *C) {
 	var riskCategoryAssessmentXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.69']")
-	rawRiskCategoryAssessments := ExtractSection(i.patientElement, riskCategoryAssessmentXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.21")
+	rawRiskCategoryAssessments := ExtractSection(i.patientElement, riskCategoryAssessmentXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.21", "")
 	i.patient.Procedures = make([]models.Procedure, len(rawRiskCategoryAssessments))
 	for j := range rawRiskCategoryAssessments {
 		i.patient.Procedures[j] = rawRiskCategoryAssessments[j].(models.Procedure)
@@ -614,7 +637,7 @@ func (i *ImporterSuite) TestExtractRiskCategoryAssessment(c *C) {
 
 func (i *ImporterSuite) TestExtractDiagnosticStudyNotPerformed(c *C) {
 	var diagnosticStudyNotPerformedXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.18']")
-	rawDiagnosticStudyNotPerformed := ExtractSection(i.patientElement, diagnosticStudyNotPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.103")
+	rawDiagnosticStudyNotPerformed := ExtractSection(i.patientElement, diagnosticStudyNotPerformedXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.103", "performed")
 	i.patient.Procedures = make([]models.Procedure, len(rawDiagnosticStudyNotPerformed))
 	for j := range rawDiagnosticStudyNotPerformed {
 		i.patient.Procedures[j] = rawDiagnosticStudyNotPerformed[j].(models.Procedure)
@@ -627,11 +650,12 @@ func (i *ImporterSuite) TestExtractDiagnosticStudyNotPerformed(c *C) {
 	c.Assert(diagnosticStudyNotPerformed.Codes["LOINC"][0], Equals, "69399-4")
 	c.Assert(diagnosticStudyNotPerformed.StartTime, Equals, int64(1225314966))
 	c.Assert(diagnosticStudyNotPerformed.EndTime, Equals, int64(1225321540))
+	c.Assert(diagnosticStudyNotPerformed.StatusCode["HL7 ActStatus"][0], Equals, "performed")
 }
 
 func (i *ImporterSuite) TestExtractDiagnosticStudyResult(c *C) {
 	var diagnosticStudyResultXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.20']")
-	rawDiagnosticStudyResults := ExtractSection(i.patientElement, diagnosticStudyResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.11")
+	rawDiagnosticStudyResults := ExtractSection(i.patientElement, diagnosticStudyResultXPath, ProcedureExtractor, "2.16.840.1.113883.3.560.1.11", "")
 	i.patient.Procedures = make([]models.Procedure, len(rawDiagnosticStudyResults))
 	for j := range rawDiagnosticStudyResults {
 		i.patient.Procedures[j] = rawDiagnosticStudyResults[j].(models.Procedure)
@@ -650,7 +674,7 @@ func (i *ImporterSuite) TestExtractDiagnosticStudyResult(c *C) {
 
 func (i *ImporterSuite) TestExtractCareGoal(c *C) {
 	var careGoalXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root='2.16.840.1.113883.10.20.24.3.1']")
-	rawCareGoals := ExtractSection(i.patientElement, careGoalXPath, CareGoalExtractor, "2.16.840.1.113883.3.560.1.9")
+	rawCareGoals := ExtractSection(i.patientElement, careGoalXPath, CareGoalExtractor, "2.16.840.1.113883.3.560.1.9", "")
 	i.patient.CareGoals = make([]models.CareGoal, len(rawCareGoals))
 	for j := range rawCareGoals {
 		i.patient.CareGoals[j] = rawCareGoals[j].(models.CareGoal)
@@ -665,7 +689,7 @@ func (i *ImporterSuite) TestExtractCareGoal(c *C) {
 
 func (i *ImporterSuite) TestExtractClinicalTrialParticipants(c *C) {
 	var clinicalTrialParticipantXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.51']")
-	rawClinicalTrialParticipants := ExtractSection(i.patientElement, clinicalTrialParticipantXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.401")
+	rawClinicalTrialParticipants := ExtractSection(i.patientElement, clinicalTrialParticipantXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.401", "")
 	i.patient.Conditions = make([]models.Condition, len(rawClinicalTrialParticipants))
 	for j := range rawClinicalTrialParticipants {
 		i.patient.Conditions[j] = rawClinicalTrialParticipants[j].(models.Condition)
@@ -681,7 +705,7 @@ func (i *ImporterSuite) TestExtractClinicalTrialParticipants(c *C) {
 func (i *ImporterSuite) TestExtractPatientCharacteristicExpired(c *C) {
 
 	var patientExpiredXPath = xpath.Compile("//cda:entry/cda:observation[cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.54']")
-	rawPatientExpireds := ExtractSection(i.patientElement, patientExpiredXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.404")
+	rawPatientExpireds := ExtractSection(i.patientElement, patientExpiredXPath, ConditionExtractor, "2.16.840.1.113883.3.560.1.404", "")
 	i.patient.Conditions = make([]models.Condition, len(rawPatientExpireds))
 	for j := range rawPatientExpireds {
 		i.patient.Conditions[j] = rawPatientExpireds[j].(models.Condition)

--- a/importer/medication.go
+++ b/importer/medication.go
@@ -40,6 +40,9 @@ func extractMedication(entry *models.Entry, entryElement xml.Node) models.Medica
 
 	extractAdministrationTiming(&medication, entryElement)
 
+	codeXPath := xpath.Compile("./cda:consumable/cda:manufacturedProduct/cda:manufacturedMaterial/cda:code")
+	ExtractCodes(&medication.Entry.Coded, entryElement, codeXPath)
+
 	routeXPath := xpath.Compile("./cda:routeCode")
 	medication.Route.Codes = map[string][]string{}
 	ExtractCodes(&medication.Route, entryElement, routeXPath)

--- a/models/code_system_map.go
+++ b/models/code_system_map.go
@@ -5,6 +5,7 @@ var oidMap = map[string]string{
 	"2.16.840.1.113883.6.1":      "LOINC",
 	"2.16.840.1.113883.6.96":     "SNOMED-CT",
 	"2.16.840.1.113883.6.88":     "RxNorm",
+	"2.16.840.1.113883.12.292":   "CVX",
 	"2.16.840.1.113883.6.103":    "ICD-9-CM",
 	"2.16.840.1.113883.6.104":    "ICD-9-PCS",
 	"2.16.840.1.113883.6.4":      "ICD-10-PCS",
@@ -14,6 +15,14 @@ var oidMap = map[string]string{
 	"2.16.840.1.113883.5.4":      "ActCode",
 }
 
+// old oids still exist in old data. this maps retired oid values to new oid values
+var oidAliases = map[string]string{
+	"2.16.840.1.113883.6.59": "2.16.840.1.113883.12.292", // CVX
+}
+
 func CodeSystemFor(oid string) string {
+	if newOid, ok := oidAliases[oid]; ok {
+		oid = newOid
+	}
 	return oidMap[oid]
 }


### PR DESCRIPTION
Import Status Codes:
- added status codes to each `ExtractSection()` function call in importer.go
- added `set_status_code()` function. function called from `ExtractEntry()` in importer.go
- added tests for status codes for each importer that has status codes

Tests for Import Medications:
- fixed xpaths in importer.go by changing `./` to `//` in xpaths
- added consumable code extractor to medication importer
- added `CVX` to code system map and added alias oid for `CVX`
