### PR TITLE
Fix Extract Entry

### DIFF
--- a/exporter/cat1_view_helper.go
+++ b/exporter/cat1_view_helper.go
@@ -82,11 +82,11 @@ func entryInfosForPatient(patient models.Record, measures []models.Measure) []en
 	mappedDataCriterias := uniqueDataCriteria(allDataCriteria(measures))
 	var entryInfos []entryInfo
 	for _, mappedDataCriteria := range mappedDataCriterias {
-		entrySections := entriesForDataCriteria(mappedDataCriteria.DataCriteria, patient)
+		var entrySections []models.HasEntry = entriesForDataCriteria(mappedDataCriteria.DataCriteria, patient)
 		// add code displays struct to each entry
 		for i, entrySection := range entrySections {
 			if entrySection != nil {
-				entry := models.ExtractEntry(&entrySections[i])
+				entry := entrySections[i].GetEntry()
 				SetCodeDisplaysForEntry(entry)
 			}
 		}
@@ -114,7 +114,7 @@ func allPerferredCodeSetsIfNeeded(cds []models.CodeDisplay) {
 }
 
 // append an entryInfo to entryInfos for each entry
-func appendEntryInfos(entryInfos []entryInfo, entries []interface{}, mappedDataCriteria mdc) []entryInfo {
+func appendEntryInfos(entryInfos []entryInfo, entries []models.HasEntry, mappedDataCriteria mdc) []entryInfo {
 	for _, entry := range entries {
 		if entry != nil {
 			entryInfo := entryInfo{EntrySection: entry, MapDataCriteria: mappedDataCriteria}
@@ -129,7 +129,7 @@ func appendEntryInfos(entryInfos []entryInfo, entries []interface{}, mappedDataC
 //   this is done so we have access to cat1Template when calling this function from _patient_data.xml
 func generateExecuteTemplateForEntry(cat1Template *template.Template) func(entryInfo) string {
 	return func(ei entryInfo) string {
-		entry := models.ExtractEntry(&ei.EntrySection)
+		entry := ei.EntrySection.GetEntry()
 		qrdaOid := HqmfToQrdaOid(entry.Oid)
 
 		templateName := fmt.Sprintf("_%v.xml", qrdaOid)
@@ -222,8 +222,8 @@ func condAssign(first int64, second int64) int64 {
 	return second
 }
 
-func codeToDisplay(i interface{}, codeType string) (models.CodeDisplay, error) {
-	entry := models.ExtractEntry(&i)
+func codeToDisplay(entrySection models.HasEntry, codeType string) (models.CodeDisplay, error) {
+	entry := entrySection.GetEntry()
 	return entry.GetCodeDisplay(codeType)
 }
 

--- a/exporter/cat1_view_helper_test.go
+++ b/exporter/cat1_view_helper_test.go
@@ -77,15 +77,15 @@ func TestAppendEntryInfos(t *testing.T) {
 	// create entry sections
 	entries := make([]models.Entry, 0)
 	entries = append(entries, models.Entry{Description: "my description"})
-	var entrySections []interface{}
+	var entrySections []models.HasEntry
 	for _, entry := range entries {
-		entrySections = append(entrySections, models.Encounter{Entry: &entry})
+		entrySections = append(entrySections, &models.Encounter{Entry: entry})
 	}
 	entrySections = append(entrySections, nil) // appendEntryInfos() function should not include nil entry sections
 
 	entryInfos := appendEntryInfos([]entryInfo{}, entrySections, mdc{})
 	assert.Equal(t, 1, len(entryInfos))
-	assert.Equal(t, "my description", models.ExtractEntry(&entryInfos[0].EntrySection).Description)
+	assert.Equal(t, "my description", entryInfos[0].EntrySection.GetEntry().Description)
 }
 
 func TestAllPreferredCodeSetsIfNeeded(t *testing.T) {
@@ -162,13 +162,13 @@ func TestCondAssign(t *testing.T) {
 func TestCodeToDisplay(t *testing.T) {
 	codeDisplays := []models.CodeDisplay{models.CodeDisplay{CodeType: "first code type"}, models.CodeDisplay{CodeType: "second code type"}}
 	entry := models.Entry{CodeDisplays: codeDisplays}
-	encounter := models.Encounter{Entry: &entry}
+	encounter := models.Encounter{Entry: entry}
 
-	codeDisplay, err := codeToDisplay(encounter, "first code type")
+	codeDisplay, err := codeToDisplay(&encounter, "first code type")
 	assert.Nil(t, err)
 	assert.Equal(t, models.CodeDisplay{CodeType: "first code type"}, codeDisplay)
 
-	codeDisplay, err = codeToDisplay(encounter, "not a code type")
+	codeDisplay, err = codeToDisplay(&encounter, "not a code type")
 	assert.NotNil(t, err)
 }
 
@@ -285,7 +285,7 @@ func unorderedStringSlicesEqual(a, b []string) bool {
 	return true
 }
 
-func numNonNil(objs []interface{}) int {
+func numNonNil(objs []models.HasEntry) int {
 	var sum int
 	for _, obj := range objs {
 		if obj != nil {

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -46,7 +46,7 @@ type mdc struct {
 // passed into each qrda oid (entry) template
 // EntrySection should be a struct that includes entry attributes (ex. Procedure, Medication, ...)
 type entryInfo struct {
-	EntrySection    interface{}
+	EntrySection    models.HasEntry
 	MapDataCriteria mdc
 }
 

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -47,10 +47,12 @@ func TestEntriesForDataCriteria(t *testing.T) {
 	json.Unmarshal(patientData, patient)
 	json.Unmarshal(measureData, measure)
 
-	var entries []interface{}
+	var entries []models.HasEntry
 	for _, crit := range measure.HQMFDocument.DataCriteria {
 		if crit.HQMFOid != "" {
-			entries = append(entries, entriesForDataCriteria(crit, *patient))
+			for _, entryForDataCriteria := range entriesForDataCriteria(crit, *patient) {
+				entries = append(entries, entryForDataCriteria)
+			}
 		}
 	}
 	// TODO: This test will have to change when we get a new export of CMS9v4a with all the HQMFOid fields filled.

--- a/exporter/hqmf_template_resolver.go
+++ b/exporter/hqmf_template_resolver.go
@@ -135,9 +135,9 @@ func codeDisplayForQrdaOid(oid string) []models.CodeDisplay {
 	return []models.CodeDisplay{}
 }
 
-// input interface should be an entry section (ex. Procedure, Medication, ...)
-func IsR2Compatible(i interface{}) bool {
+// input entrySection should be an entry section (ex. Procedure, Medication, ...)
+func IsR2Compatible(entrySection models.HasEntry) bool {
 	initializeMap()
-	entry := models.ExtractEntry(&i)
+	entry := entrySection.GetEntry()
 	return hqmfQrdaMap[entry.Oid] != nil
 }

--- a/exporter/hqmf_template_resolver_test.go
+++ b/exporter/hqmf_template_resolver_test.go
@@ -32,10 +32,10 @@ func TestCodeDisplayForQrdaOid(t *testing.T) {
 
 func TestIsR2Compatible(t *testing.T) {
 	// invalid hqmf oid
-	entry := models.Encounter{Entry: &models.Entry{Oid: "not a valid hqmf r2 oid"}}
-	assert.Equal(t, false, IsR2Compatible(entry))
+	entry := models.Encounter{Entry: models.Entry{Oid: "not a valid hqmf r2 oid"}}
+	assert.Equal(t, false, IsR2Compatible(&entry))
 
 	// valid hqmf oid
-	entry = models.Encounter{Entry: &models.Entry{Oid: "2.16.840.1.113883.3.560.1.10"}}
-	assert.Equal(t, true, IsR2Compatible(entry))
+	entry = models.Encounter{Entry: models.Entry{Oid: "2.16.840.1.113883.3.560.1.10"}}
+	assert.Equal(t, true, IsR2Compatible(&entry))
 }

--- a/exporter/templates.go
+++ b/exporter/templates.go
@@ -100,7 +100,7 @@ func templatesCat1_Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1464875542, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -120,7 +120,7 @@ func templatesCat1_2168401113883102024323Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_2.16.840.1.113883.10.20.24.3.23.xml", size: 2997, mode: os.FileMode(420), modTime: time.Unix(1464875579, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_2.16.840.1.113883.10.20.24.3.23.xml", size: 2997, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -140,7 +140,7 @@ func templatesCat1_addressXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -160,7 +160,7 @@ func templatesCat1_authorXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_author.xml", size: 822, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_author.xml", size: 822, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -180,7 +180,7 @@ func templatesCat1_codeXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_code.xml", size: 579, mode: os.FileMode(420), modTime: time.Unix(1464875579, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_code.xml", size: 579, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -200,7 +200,7 @@ func templatesCat1_idXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -220,7 +220,7 @@ func templatesCat1_measuresXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_measures.xml", size: 2597, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_measures.xml", size: 2597, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -240,7 +240,7 @@ func templatesCat1_organizationXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -260,7 +260,7 @@ func templatesCat1_patient_dataXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_patient_data.xml", size: 641, mode: os.FileMode(420), modTime: time.Unix(1464875542, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_patient_data.xml", size: 641, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -280,7 +280,7 @@ func templatesCat1_providersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_providers.xml", size: 2131, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_providers.xml", size: 2131, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -300,7 +300,7 @@ func templatesCat1_reasonXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_reason.xml", size: 1424, mode: os.FileMode(420), modTime: time.Unix(1464875579, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_reason.xml", size: 1424, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -320,7 +320,7 @@ func templatesCat1_record_targetXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_record_target.xml", size: 2606, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_record_target.xml", size: 2606, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -340,7 +340,7 @@ func templatesCat1_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_reporting_parameters.xml", size: 1079, mode: os.FileMode(420), modTime: time.Unix(1460645927, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_reporting_parameters.xml", size: 1079, mode: os.FileMode(420), modTime: time.Unix(1460741990, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -360,7 +360,7 @@ func templatesCat1_telecomXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1462547474, 0)}
+	info := bindataFileInfo{name: "templates/cat1/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1462198733, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -380,7 +380,7 @@ func templatesCat1Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/cat1.xml", size: 5124, mode: os.FileMode(420), modTime: time.Unix(1464875542, 0)}
+	info := bindataFileInfo{name: "templates/cat1/cat1.xml", size: 5124, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -400,7 +400,7 @@ func hqmfr2_template_oid_mapJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmfr2_template_oid_map.json", size: 11609, mode: os.FileMode(420), modTime: time.Unix(1460645927, 0)}
+	info := bindataFileInfo{name: "hqmfr2_template_oid_map.json", size: 11609, mode: os.FileMode(420), modTime: time.Unix(1460741990, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -420,7 +420,7 @@ func hqmf_template_oid_mapJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_template_oid_map.json", size: 20534, mode: os.FileMode(420), modTime: time.Unix(1460645927, 0)}
+	info := bindataFileInfo{name: "hqmf_template_oid_map.json", size: 20534, mode: os.FileMode(420), modTime: time.Unix(1460741990, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -440,7 +440,7 @@ func hqmf_qrda_oidsJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_qrda_oids.json", size: 22472, mode: os.FileMode(420), modTime: time.Unix(1464875579, 0)}
+	info := bindataFileInfo{name: "hqmf_qrda_oids.json", size: 22472, mode: os.FileMode(420), modTime: time.Unix(1464973699, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/exporter/templates_test.go
+++ b/exporter/templates_test.go
@@ -91,9 +91,9 @@ func xmlReasonRootNode(reason models.CodedConcept, negateReason bool, r2Compatab
 func getReasonData(reason models.CodedConcept, negateReason bool, r2CompatableQrdaOid bool) *entryInfo {
 	encounter := models.Encounter{}
 	if negateReason {
-		encounter.Entry = &models.Entry{NegationReason: reason}
+		encounter.Entry = models.Entry{NegationReason: reason}
 	} else {
-		encounter.Entry = &models.Entry{Reason: reason}
+		encounter.Entry = models.Entry{Reason: reason}
 	}
 	encounter.StartTime = int64(0)
 	if r2CompatableQrdaOid {
@@ -101,7 +101,7 @@ func getReasonData(reason models.CodedConcept, negateReason bool, r2CompatableQr
 	} else {
 		encounter.Entry.Oid = "invalid_qrda_oid"
 	}
-	return &entryInfo{EntrySection: encounter}
+	return &entryInfo{EntrySection: &encounter}
 }
 
 func setMapDataCriteria(ei *entryInfo) {
@@ -131,7 +131,7 @@ func TestEncounterPerformedTemplate(t *testing.T) {
 
 	// test admit time vs start time for <low> tag. test discharge time vs end time for <high> tag
 	ei := getDataForQrdaOid(qrdaOid)
-	entrySection := ei.EntrySection.(models.Encounter)
+	entrySection := ei.EntrySection.(*models.Encounter)
 	entrySection.AdmitTime = 1262462640 // is time 2010 01 02 1504 in EST
 	entrySection.StartTime = 0
 	entrySection.DischargeTime = 1293998640 // is time 2011 01 02 1504 in EST
@@ -289,7 +289,7 @@ func generateTemplateForFile(temp *template.Template, fileName string, templateD
 func getEntryInfo(patient models.Record, measures []models.Measure, qrdaOid string) (entryInfo, error) {
 	entryInfos := entryInfosForPatient(patient, measures)
 	for _, ei := range entryInfos {
-		if qrdaOid == HqmfToQrdaOid(models.ExtractEntry(&ei.EntrySection).Oid) {
+		if qrdaOid == HqmfToQrdaOid(ei.EntrySection.GetEntry().Oid) {
 			return ei, nil
 		}
 	}

--- a/importer/encounter.go
+++ b/importer/encounter.go
@@ -8,7 +8,7 @@ import (
 
 func EncounterOrderExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	encounterOrder := models.Encounter{}
-	encounterOrder.Entry = entry
+	encounterOrder.Entry = *entry
 
 	//extract codes
 	var codePath = xpath.Compile("cda:code")
@@ -24,7 +24,7 @@ func EncounterOrderExtractor(entry *models.Entry, entryElement xml.Node) interfa
 
 func EncounterPerformedExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	encounter := models.Encounter{}
-	encounter.Entry = entry
+	encounter.Entry = *entry
 
 	//extract codes
 	var codePath = xpath.Compile("cda:code")

--- a/importer/transfer.go
+++ b/importer/transfer.go
@@ -9,7 +9,7 @@ import (
 // returns Encounter with TransferFrom field
 func TransferFromExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	transferFromEncounter := models.Encounter{}
-	transferFromEncounter.Entry = entry
+	transferFromEncounter.Entry = *entry
 
 	extractCodes(&transferFromEncounter.Entry.Coded, entryElement)
 	extractTimes(&transferFromEncounter, &transferFromEncounter.TransferFrom, entryElement)
@@ -23,7 +23,7 @@ func TransferFromExtractor(entry *models.Entry, entryElement xml.Node) interface
 // returns Encounter with TransferTo field
 func TransferToExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	transferToEncounter := models.Encounter{}
-	transferToEncounter.Entry = entry
+	transferToEncounter.Entry = *entry
 
 	extractCodes(&transferToEncounter.Entry.Coded, entryElement)
 	extractTimes(&transferToEncounter, &transferToEncounter.TransferTo, entryElement)

--- a/models/allergy.go
+++ b/models/allergy.go
@@ -6,3 +6,7 @@ type Allergy struct {
 	Reaction Coded `json:"reaction,omitempty"`
 	Severity Coded `json:"severity,omitempty"`
 }
+
+func (al *Allergy) GetEntry() *Entry {
+	return &al.Entry
+}

--- a/models/communication.go
+++ b/models/communication.go
@@ -4,3 +4,7 @@ type Communication struct {
 	Entry     `bson:",inline"`
 	Direction string `json:"direction,omitempty"`
 }
+
+func (com *Communication) GetEntry() *Entry {
+	return &com.Entry
+}

--- a/models/condition.go
+++ b/models/condition.go
@@ -21,3 +21,7 @@ type Laterality struct {
 	CodedConcept `bson:",inline"`
 	Title        string `json:"title,omitempty"`
 }
+
+func (con *Condition) GetEntry() *Entry {
+	return &con.Entry
+}

--- a/models/encounter.go
+++ b/models/encounter.go
@@ -1,8 +1,12 @@
 package models
 
 type Encounter struct {
-	*Entry               `bson:",inline"`
+	Entry                `bson:",inline"`
 	AdmitTime            int64             `json:"admitTime,omitempty"`
 	DischargeTime        int64             `json:"discharge_time,omitempty"`
 	DischargeDisposition map[string]string `json:"discharge_disposition,omitempty"`
+}
+
+func (enc *Encounter) GetEntry() *Entry {
+	return &enc.Entry
 }

--- a/models/entry.go
+++ b/models/entry.go
@@ -3,9 +3,6 @@ package models
 import (
 	"errors"
 	"fmt"
-	"reflect"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 type Entry struct {
@@ -41,33 +38,12 @@ type CodeDisplay struct {
 	Description            string   `json:"description"`
 }
 
-func ExtractEntry(entry *interface{}) *Entry {
+type HasEntry interface {
+	GetEntry() *Entry
+}
 
-	switch t := (*entry).(type) {
-	case Encounter:
-		return t.Entry
-	case LabResult:
-		return &t.Entry
-	case InsuranceProvider:
-		return &t.Entry
-	case Procedure:
-		return &t.Entry
-	case Allergy:
-		return &t.Entry
-	case Medication:
-		return &t.Entry
-	case Communication:
-		return &t.Entry
-	case Condition:
-		return &t.Entry
-	case ProviderPerformance:
-		return &t.Entry
-	case Entry:
-		return &t
-	default:
-		spew.Dump(reflect.TypeOf(entry))
-		panic("We don't know how to extract an Entry from this type")
-	}
+func (entry *Entry) GetEntry() *Entry {
+	return entry
 }
 
 // returns codeDisplay. also returns true if code display was found and false if not found

--- a/models/entry_test.go
+++ b/models/entry_test.go
@@ -37,3 +37,18 @@ func TestNegationReasonOrReason(t *testing.T) {
 	entry = Entry{}
 	assert.Equal(t, CodedConcept{}, entry.NegationReasonOrReason())
 }
+
+func TestExtractEntryFromEncounter(t *testing.T) {
+	entry := Entry{Description: "my entry's description"}
+	var encounter HasEntry = &Encounter{Entry: entry}
+	extractedEntry := encounter.GetEntry()
+	assert.Equal(t, entry, *extractedEntry)
+}
+
+func TestExtractedEntryCanBeEdited(t *testing.T) {
+	var encounter HasEntry = &Encounter{Entry: Entry{Description: "my entry's description"}}
+	firstExtractedEntry := encounter.GetEntry()
+	firstExtractedEntry.Description = "different description from before"
+	secondExtractedEntry := encounter.GetEntry()
+	assert.Equal(t, *firstExtractedEntry, *secondExtractedEntry)
+}

--- a/models/insurance_provider.go
+++ b/models/insurance_provider.go
@@ -21,6 +21,10 @@ type Guarantor struct {
 	EndTime      int64        `json:"end_time"`
 }
 
+func (ip *InsuranceProvider) GetEntry() *Entry {
+	return &ip.Entry
+}
+
 // ShiftDates adds dateDiff to start/end times/other times for Insurance Providers
 func (p *InsuranceProvider) ShiftDates(dateDiff int64) {
 	p.StartTime = shiftDate(p.StartTime, dateDiff)

--- a/models/lab_result.go
+++ b/models/lab_result.go
@@ -5,3 +5,7 @@ type LabResult struct {
 	ReferenceRange string       `json:"referenceRange,omitempty"`
 	Interpretation CodedConcept `json:"interpretation,omitempty"`
 }
+
+func (lr *LabResult) GetEntry() *Entry {
+	return &lr.Entry
+}

--- a/models/medication.go
+++ b/models/medication.go
@@ -41,3 +41,7 @@ type OrderInformation struct {
 	OrderExpiration int64  `json:"order_expiration_date_time,omitempty"`
 	OrderDate       int64  `json:"order_date_time,omitempty"`
 }
+
+func (med *Medication) GetEntry() *Entry {
+	return &med.Entry
+}

--- a/models/models.go
+++ b/models/models.go
@@ -102,51 +102,50 @@ type Record struct {
 }
 
 // Entries returns all the entries from the Encounters, Diagnoses, and LabResults for a Record
-func (r *Record) Entries() []interface{} {
-	var entries []interface{}
+func (r *Record) Entries() []HasEntry {
+	var entries []HasEntry
 
-	// This whole "for loop for each of these things" is unavoidable, because elements must be copied individually to a []interface{}
-	for _, en := range r.Encounters {
-		entries = append(entries, en)
+	// This whole "for loop for each of these things" is unavoidable, because elements must be copied individually to a []HasEntry
+	for i, _ := range r.Encounters {
+		entries = append(entries, &r.Encounters[i])
 	}
 
-	for _, lr := range r.LabResults {
-		entries = append(entries, lr)
+	for i, _ := range r.LabResults {
+		entries = append(entries, &r.LabResults[i])
 	}
 
-	for _, ip := range r.InsuranceProviders {
-		entries = append(entries, ip)
+	for i, _ := range r.InsuranceProviders {
+		entries = append(entries, &r.InsuranceProviders[i])
 	}
 
-	for _, pp := range r.ProviderPerformances {
-		entries = append(entries, pp)
+	for i, _ := range r.ProviderPerformances {
+		entries = append(entries, &r.ProviderPerformances[i])
 	}
 
-	for _, pr := range r.Procedures {
-		entries = append(entries, pr)
+	for i, _ := range r.Procedures {
+		entries = append(entries, &r.Procedures[i])
 	}
 
-	for _, md := range r.Medications {
-		entries = append(entries, md)
+	for i, _ := range r.Medications {
+		entries = append(entries, &r.Medications[i])
 	}
 
-	for _, al := range r.Allergies {
-		entries = append(entries, al)
+	for i, _ := range r.Allergies {
+		entries = append(entries, &r.Allergies[i])
 	}
 
-	for _, cn := range r.Conditions {
-		entries = append(entries, cn)
+	for i, _ := range r.Conditions {
+		entries = append(entries, &r.Conditions[i])
 	}
 
 	return entries
 }
 
 // EntriesForOid returns all the entries which include the OID
-func (r *Record) EntriesForOid(oid string) []interface{} {
-	var matchedEntries []interface{}
+func (r *Record) EntriesForOid(oid string) []HasEntry {
+	var matchedEntries []HasEntry
 	for _, entry := range r.Entries() {
-
-		if ExtractEntry(&entry).Oid == oid {
+		if entry.GetEntry().Oid == oid {
 			matchedEntries = append(matchedEntries, entry)
 		}
 	}
@@ -164,12 +163,6 @@ type ResultValue struct {
 type CDAIdentifier struct {
 	Root      string `json:"root,omitempty"`
 	Extension string `json:"extension,omitempty"`
-}
-
-type ProviderPerformance struct {
-	Entry     `bson:",inline"`
-	StartDate int64 `json:"startDate,omitempty"`
-	EndDate   int64 `json:"endDate,omitempty"`
 }
 
 type Scalar struct {

--- a/models/procedure.go
+++ b/models/procedure.go
@@ -13,6 +13,10 @@ type Procedure struct {
 type Performer struct {
 }
 
+func (proc *Procedure) GetEntry() *Entry {
+	return &proc.Entry
+}
+
 // used so bson.Marshal() and bson.Unmarshal() will not recursively call GetBSON() and SetBSON() respectively
 type ProcedureNoFunc Procedure
 

--- a/models/provider_performance.go
+++ b/models/provider_performance.go
@@ -1,0 +1,11 @@
+package models
+
+type ProviderPerformance struct {
+	Entry     `bson:",inline"`
+	StartDate int64 `json:"startDate,omitempty"`
+	EndDate   int64 `json:"endDate,omitempty"`
+}
+
+func (pp *ProviderPerformance) GetEntry() *Entry {
+	return &pp.Entry
+}


### PR DESCRIPTION
- changed all entry sections (Procedure, Medication, ...) to be passed as `HasEntry` interface instead of `interface{}`
- `HasEntry` interface implements the `GetEntry()` function: a replacement for the `ExtractEntry()` function
- The `Entry` type also implements the `HasEntry` interface
- moved provider performance model to separate model file
