### PR TITLE
Remove codeToDisplay()

### DIFF
--- a/exporter/cat1_view_helper.go
+++ b/exporter/cat1_view_helper.go
@@ -205,11 +205,6 @@ func condAssign(first interface{}, second interface{}) interface{} {
 	return result
 }
 
-func codeToDisplay(entrySection models.HasEntry, codeType string) (models.CodeDisplay, error) {
-	entry := entrySection.GetEntry()
-	return entry.GetCodeDisplay(codeType)
-}
-
 func codeDisplayWithPreferredCode(entry *models.Entry, coded *models.Coded, codeType string) models.CodeDisplay {
 	codeDisplay, err := entry.GetCodeDisplay(codeType)
 	util.CheckErr(err)

--- a/exporter/cat1_view_helper_test.go
+++ b/exporter/cat1_view_helper_test.go
@@ -106,19 +106,6 @@ func TestCondAssign(t *testing.T) {
 	assert.Equal(t, &first, condAssign(&first, second))
 }
 
-func TestCodeToDisplay(t *testing.T) {
-	codeDisplays := []models.CodeDisplay{models.CodeDisplay{CodeType: "first code type"}, models.CodeDisplay{CodeType: "second code type"}}
-	entry := models.Entry{CodeDisplays: codeDisplays}
-	encounter := models.Encounter{Entry: entry}
-
-	codeDisplay, err := codeToDisplay(&encounter, "first code type")
-	assert.Nil(t, err)
-	assert.Equal(t, models.CodeDisplay{CodeType: "first code type"}, codeDisplay)
-
-	codeDisplay, err = codeToDisplay(&encounter, "not a code type")
-	assert.NotNil(t, err)
-}
-
 func TestCodeDisplayWithPreferredCode(t *testing.T) {
 	codeType := "my code type"
 	expectedCodeDisplay := models.CodeDisplay{CodeType: codeType, PreferredCodeSets: []string{"codeSetB"}}

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -37,7 +37,6 @@ func exporterFuncMap(cat1Template *template.Template, vsMap models.ValueSetMap) 
 		"sdtcValueSetAttribute":                     sdtcValueSetAttribute,
 		"getTransferOid":                            getTransferOid,
 		"identifierForInterface":                    identifierForInterface,
-		"codeToDisplay":                             codeToDisplay,
 		"valueOrDefault":                            valueOrDefault,
 		"oidForCodeSystem":                          oidForCodeSystem,
 		"oidForCode":                                vsMap.OidForCode,

--- a/exporter/templates.go
+++ b/exporter/templates.go
@@ -2426,6 +2426,7 @@ type bintree struct {
 	Func     func() (*asset, error)
 	Children map[string]*bintree
 }
+
 var _bintree = &bintree{nil, map[string]*bintree{
 	"hqmf_qrda_oids.json": &bintree{hqmf_qrda_oidsJson, map[string]*bintree{}},
 	"hqmf_qrda_oids_r3_1.json": &bintree{hqmf_qrda_oids_r3_1Json, map[string]*bintree{}},
@@ -2586,4 +2587,3 @@ func _filePath(dir, name string) string {
 	cannonicalName := strings.Replace(name, "\\", "/", -1)
 	return filepath.Join(append([]string{dir}, strings.Split(cannonicalName, "/")...)...)
 }
-


### PR DESCRIPTION
This function is not necessary since all it does is get the Entry
from the struct that satisfies the interface and call the Entry's
GetCodeDisplay() method. This can be called directly on the struct
that satisfies the interface because they all have Entry embedded
in them, thus they are Entries and have that method available.