### PR TITLE
Add initial refactor to MVVM for exporter.

### DIFF
--- a/exporter/document/allergy.go
+++ b/exporter/document/allergy.go
@@ -1,0 +1,74 @@
+package document
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/projectcypress/cdatools/models"
+)
+
+type Allergy struct {
+	models.Allergy
+}
+
+func NewAllergy(a models.Allergy) Allergy {
+	return Allergy{Allergy: a}
+}
+
+func (a Allergy) Print() string {
+	tmpl, err := template.New("").Parse(a.cat1Template())
+	if err != nil {
+		fmt.Println("error making template:")
+		fmt.Println(err)
+		return ""
+	}
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, a)
+	if err != nil {
+		fmt.Println("error executing template:")
+		fmt.Println(err)
+		return ""
+	}
+	return b.String()
+}
+
+// NOTE: Need to add this into the template above .Description
+// <!--<%== code_display(entry,'value_set_map'
+// => filtered_vs_map, 'preferred_code_sets'
+// => ['RxNorm', 'SNOMED-CT', 'CVX'], 'extra_content'
+// => "sdtc:valueSet=\"#{value_set_oid}\"") %>-->
+func (a Allergy) cat1Template() string {
+	t := `
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- consolidation CDA Allergy Observation template -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.7" extension="2014-06-09"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.46" extension="2014-12-01"/>
+    <id root="1.3.6.1.4.1.115" extension="{{ .ID.Extension }}"/>
+    <code code="ASSERTION" 
+          displayName="Assertion" 
+          codeSystem="2.16.840.1.113883.5.4" 
+          codeSystemName="ActCode"/>
+    <statusCode code="completed"/>
+    <effectiveTime>
+      <!--<low valueOrNullFlavor .StartTime/>-->
+      <low {{ .StartTime }}/>
+    </effectiveTime>
+    <value xsi:type="CD" 
+           code="59037007" 
+           displayName="Drug intolerance"
+           codeSystem="2.16.840.1.113883.6.96" 
+           codeSystemName="SNOMED CT"/>
+    <participant typeCode="CSM">
+      <participantRole classCode="MANU">
+        <playingEntity classCode="MMAT">
+          <name>{{ .Description }}</name>
+        </playingEntity>
+      </participantRole>
+    </participant>
+  </observation>
+</entry>`
+
+	return t
+}

--- a/exporter/document/allergy_test.go
+++ b/exporter/document/allergy_test.go
@@ -1,0 +1,61 @@
+package document_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/projectcypress/cdatools/exporter/document"
+	"github.com/projectcypress/cdatools/models"
+)
+
+func TestPrint(t *testing.T) {
+	startTime := int64(1)
+	var tests = []struct {
+		n        document.Allergy
+		expected string
+	}{
+		{
+			document.NewAllergy(models.Allergy{
+				Entry: models.Entry{StartTime: &startTime, Description: "A test allergy", ID: models.CDAIdentifier{Extension: "extension"}}}),
+			fmt.Sprintf(allergyCat1TestTemplate, "extension", 1, "A test allergy"),
+		},
+	}
+
+	for _, tt := range tests {
+		actual := tt.n.Print()
+		if actual != tt.expected {
+			t.Errorf("Allergy.Print(): expected %s, actual %s", tt.expected, actual)
+		}
+	}
+}
+
+var allergyCat1TestTemplate = `
+<entry>
+  <observation classCode="OBS" moodCode="EVN">
+    <!-- consolidation CDA Allergy Observation template -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.7" extension="2014-06-09"/>
+    <templateId root="2.16.840.1.113883.10.20.24.3.46" extension="2014-12-01"/>
+    <id root="1.3.6.1.4.1.115" extension="%s"/>
+    <code code="ASSERTION" 
+          displayName="Assertion" 
+          codeSystem="2.16.840.1.113883.5.4" 
+          codeSystemName="ActCode"/>
+    <statusCode code="completed"/>
+    <effectiveTime>
+      <!--<low valueOrNullFlavor .StartTime/>-->
+      <low %d/>
+    </effectiveTime>
+    <value xsi:type="CD" 
+           code="59037007" 
+           displayName="Drug intolerance"
+           codeSystem="2.16.840.1.113883.6.96" 
+           codeSystemName="SNOMED CT"/>
+    <participant typeCode="CSM">
+      <participantRole classCode="MANU">
+        <playingEntity classCode="MMAT">
+          <name>%s</name>
+        </playingEntity>
+      </participantRole>
+    </participant>
+  </observation>
+</entry>`

--- a/exporter/document/cat1.go
+++ b/exporter/document/cat1.go
@@ -1,0 +1,82 @@
+package document
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/projectcypress/cdatools/models"
+)
+
+type Cat1 struct {
+	//EntryInfos []models.EntryInfo
+	Record models.Record
+	Header models.Header
+	//Measures   []models.Measure
+	//ValueSets  []models.ValueSet
+	//StartDate  int64
+	//EndDate    int64
+}
+
+func NewCat1() Cat1 {
+	return *new(Cat1)
+}
+
+func (c Cat1) Print() string {
+	tmpl, err := template.New("").Parse(c.template())
+	if err != nil {
+		fmt.Println("error making template:")
+		fmt.Println(err)
+		return ""
+	}
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, c)
+	if err != nil {
+		fmt.Println("error executing template:")
+		fmt.Println(err)
+		return ""
+	}
+	return b.String()
+}
+
+func (c Cat1) template() string {
+	template := `<?xml version="1.0" encoding="utf-8"?>
+<ClinicalDocument xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="urn:hl7-org:v3"
+ xmlns:voc="urn:hl7-org:v3/voc"
+ xmlns:sdtc="urn:hl7-org:sdtc">
+  <!-- QRDA Header -->
+  <realmCode code="US"/>
+  <typeId root="2.16.840.1.113883.1.3" extension="POCD_HD000040"/>
+  <!-- US Realm Header Template Id -->
+  <templateId root="2.16.840.1.113883.10.20.22.1.1" extension="2014-06-09" />
+  <!-- QRDA templateId -->
+  <templateId root="2.16.840.1.113883.10.20.24.1.1" extension="2014-12-01" />
+  <!-- QDM-based QRDA templateId -->
+  <templateId root="2.16.840.1.113883.10.20.24.1.2" />
+  <!-- This is the globally unique identifier for this QRDA document -->
+  <id root="{{ newRandom }}"/>
+  <!-- QRDA document type code -->
+  <code code="55182-0" codeSystem="2.16.840.1.113883.6.1" codeSystemName="LOINC" displayName="Quality Measure Report"/>
+  <title>QRDA Incidence Report</title>
+  <!-- This is the document creation time -->
+  <effectiveTime value="{{ timeNow }}"/>
+  <confidentialityCode code="N" codeSystem="2.16.840.1.113883.5.25"/>
+  <languageCode code="en"/>
+  <!-- reported patient -->
+    {{template "_record_target.xml" .Record}}
+  {{ .Header.Cat1View() }}
+  {{template "_providers.xml" .Record}}
+  <component>
+    <structuredBody>
+      {{template "_measures.xml" .Measures}}
+      {{template "_reporting_parameters.xml" .}}
+      {{ .PatientData.Cat1View() }}
+    </structuredBody>
+  </component>
+
+</ClinicalDocument>
+`
+
+	return template
+}

--- a/exporter/document/header.go
+++ b/exporter/document/header.go
@@ -1,0 +1,295 @@
+package document
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/projectcypress/cdatools/models"
+)
+
+type Header struct {
+	Authenticator models.Authenticator
+	Authors       []models.Author
+	Custodian     models.Author
+}
+
+func NewHeader() Header {
+	var atime1 = new(int64)
+	var atime2 = new(int64)
+	*atime1 = 1449686219
+	*atime2 = 1449686219
+	h := &Header{
+		Authors: []models.Author{
+			models.Author{
+				Time: atime1,
+				Entity: models.Entity{
+					Ids: []models.CDAIdentifier{
+						models.CDAIdentifier{
+							Root:      "authorRoot",
+							Extension: "authorExtension",
+						},
+					},
+					Addresses: []models.Address{
+						models.Address{
+							Street: []string{
+								"202 Burlington Road",
+								"Apartment 1",
+							},
+							City:    "Bedford",
+							State:   "MA",
+							Zip:     "01730",
+							Country: "USA",
+							Use:     "PUB",
+						},
+					},
+					Telecoms: []models.Telecom{
+						models.Telecom{
+							Use:   "WP",
+							Value: "1(781)2712000",
+						},
+					},
+				},
+				Device: models.Device{
+					Name:  "deviceName",
+					Model: "deviceModel",
+				},
+				Organization: models.Organization{
+					Entity: models.Entity{
+						Ids: []models.CDAIdentifier{
+							models.CDAIdentifier{
+								Root:      "authorsOrganizationRoot",
+								Extension: "authorsOrganizationExt",
+							},
+						},
+					},
+					Name:    "authorsOrganization",
+					TagName: "representedOrganization",
+				},
+			},
+		},
+		Custodian: models.Author{
+			Entity: models.Entity{
+				Ids: []models.CDAIdentifier{
+					models.CDAIdentifier{
+						Root:      "custodianRoot",
+						Extension: "custodianExtension",
+					},
+				},
+			},
+			Person: models.Person{
+				First: "",
+				Last:  "",
+			},
+			Organization: models.Organization{
+				Entity: models.Entity{
+					Ids: []models.CDAIdentifier{
+						models.CDAIdentifier{
+							Root:      "custodianOrganizationRoot",
+							Extension: "custodianOrganzationExt",
+						},
+					},
+					Addresses: []models.Address{
+						models.Address{
+							Street: []string{
+								"202 Burlington Road",
+								"Apartment 1",
+							},
+							City:    "Bedford",
+							State:   "MA",
+							Zip:     "01730",
+							Country: "USA",
+							Use:     "PUB",
+						},
+					},
+					Telecoms: []models.Telecom{
+						models.Telecom{
+							Use:   "WP",
+							Value: "1(781)2712000",
+						},
+					},
+				},
+				Name:    "CustodianOrganization",
+				TagName: "representedCustodianOrganization",
+			},
+		},
+		Authenticator: models.Authenticator{
+			Author: models.Author{
+				Entity: models.Entity{
+					Ids: []models.CDAIdentifier{
+						models.CDAIdentifier{
+							Root:      "legalAuthenticatorRoot",
+							Extension: "legalAuthenticatorExt",
+						},
+					},
+					Addresses: []models.Address{
+						models.Address{
+							Street: []string{
+								"202 Burlington Road",
+								"Apartment 1",
+							},
+							City:    "Bedford",
+							State:   "MA",
+							Zip:     "01730",
+							Country: "USA",
+							Use:     "PUB",
+						},
+					},
+					Telecoms: []models.Telecom{
+						models.Telecom{
+							Use:   "WP",
+							Value: "1(781)2712000",
+						},
+					},
+				},
+				Time: atime2,
+				Person: models.Person{
+					First: "Legal",
+					Last:  "Authenticator",
+				},
+				Organization: models.Organization{
+					Entity: models.Entity{
+						Ids: []models.CDAIdentifier{
+							models.CDAIdentifier{
+								Root:      "legalAuthenticatorOrgRoot",
+								Extension: "legalAuthenticatorOrgExt",
+							},
+						},
+					},
+					Name:    "LegalAuthenticatorOrg",
+					TagName: "representedOrganization",
+				},
+			},
+		},
+	}
+	return *h
+}
+
+func (h Header) Print() string {
+	tmpl, err := template.New("").Parse(h.cat1Template())
+	if err != nil {
+		fmt.Println("error making template:")
+		fmt.Println(err)
+		return ""
+	}
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, h)
+	if err != nil {
+		fmt.Println("error executing template:")
+		fmt.Println(err)
+		return ""
+	}
+	return b.String()
+}
+
+func (h Header) cat1Template() string {
+	t := `    {{if .Header}}
+    {{range .Header.Authors}}
+      {{template "_author.xml" .}}
+    {{end}}
+    <!-- SHALL have 1..* author. MAY be device or person.
+      The author of the CDA document in this example is a device at a data submission vendor/registry. -->
+
+    <!-- The custodian of the CDA document is the same as the legal authenticator in this
+    example and represents the reporting organization. -->
+    <!-- SHALL -->
+    <custodian>
+      <assignedCustodian>
+        {{template "_organization.xml" .Header.Custodian.Organization}}
+      </assignedCustodian>
+    </custodian>
+
+    <!-- The legal authenticator of the CDA document is a single person who is at the
+      same organization as the custodian in this example. This element must be present. -->
+    <!-- SHALL -->
+    <legalAuthenticator>
+      <!-- SHALL -->
+      <time value="{{escape .Header.Authenticator.Time}}"/>
+      <!-- SHALL -->
+      <signatureCode code="S"/>
+      <assignedEntity>
+        <!-- SHALL ID -->
+        {{range .Header.Authenticator.Ids}}
+          {{template "_id.xml" .}}
+        {{end}}
+        {{range .Header.Authenticator.Addresses}}
+          {{template "_address.xml" .}}
+        {{end}}
+        {{range .Header.Authenticator.Telecoms}}
+          {{template "_telecom.xml" .}}
+        {{end}}
+        <assignedPerson>
+          <name>
+             <given>{{escape .Header.Authenticator.Person.First}}</given>
+             <family>{{escape .Header.Authenticator.Person.Last}}</family>
+          </name>
+       </assignedPerson>
+        {{template "_organization.xml" .Header.Authenticator.Organization}}
+      </assignedEntity>
+    </legalAuthenticator>
+
+  {{ else }}
+    <author>
+    <time value="{{ timeNow }}"/>
+    <assignedAuthor>
+      <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
+      <!-- NPI -->
+      <id extension="FakeNPI" root="2.16.840.1.113883.4.6"/>
+      <addr>
+        <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+        <city>Bedford</city>
+        <state>MA</state>
+        <postalCode>01730</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:(781)271-3000"/>
+      <assignedAuthoringDevice>
+        <manufacturerModelName>Cypress</manufacturerModelName >
+        <softwareName>Cypress</softwareName >
+      </assignedAuthoringDevice >
+    </assignedAuthor>
+  </author>
+  <custodian>
+    <assignedCustodian>
+      <representedCustodianOrganization>
+        <id root="2.16.840.1.113883.19.5"/>
+        <name>Cypress Test Deck</name>
+        <telecom use="WP" value="tel:(781)271-3000"/>
+        <addr>
+          <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+          <city>Bedford</city>
+          <state>MA</state>
+          <postalCode>01730</postalCode>
+          <country>US</country>
+        </addr>
+      </representedCustodianOrganization>
+    </assignedCustodian>
+  </custodian>
+  <legalAuthenticator>
+    <time value="{{ timeNow }}"/>
+    <signatureCode code="S"/>
+    <assignedEntity>
+      <id root="bc01a5d1-3a34-4286-82cc-43eb04c972a7"/>
+      <addr>
+        <streetAddressLine>202 Burlington Rd.</streetAddressLine>
+        <city>Bedford</city>
+        <state>MA</state>
+        <postalCode>01730</postalCode>
+        <country>US</country>
+      </addr>
+      <telecom use="WP" value="tel:(781)271-3000"/>
+      <assignedPerson>
+        <name>
+           <given>Henry</given>
+           <family>Seven</family>
+        </name>
+     </assignedPerson>
+      <representedOrganization>
+        <id root="2.16.840.1.113883.19.5"/>
+        <name>Cypress</name>
+      </representedOrganization>
+    </assignedEntity>
+  </legalAuthenticator>
+  {{end}}`
+	return t
+}

--- a/exporter/document/patient_data.go
+++ b/exporter/document/patient_data.go
@@ -1,0 +1,54 @@
+package document
+
+import (
+	"bytes"
+	"fmt"
+	"text/template"
+
+	"github.com/projectcypress/cdatools/models"
+)
+
+type PatientData struct {
+	models.Record
+}
+
+func NewPatientData() PatientData {
+	return *new(PatientData)
+}
+
+func (p PatientData) Print() string {
+	tmpl, err := template.New("").Parse(p.cat1Template())
+	if err != nil {
+		fmt.Println("error making template:")
+		fmt.Println(err)
+		return ""
+	}
+	var b bytes.Buffer
+	err = tmpl.Execute(&b, p)
+	if err != nil {
+		fmt.Println("error executing template:")
+		fmt.Println(err)
+		return ""
+	}
+	return b.String()
+}
+
+func (p PatientData) cat1Template() string {
+	t := `<component>
+<section>
+    <!-- This is the templateId for Patient Data section -->
+    <templateId root="2.16.840.1.113883.10.20.17.2.4"/>
+    <!-- This is the templateId for Patient Data QDM section -->
+    <templateId root="2.16.840.1.113883.10.20.24.2.1" extension="2014-12-01" />
+    <code code="55188-7" codeSystem="2.16.840.1.113883.6.1"/>
+    <title>Patient Data</title>
+    <text>
+    </text>
+    {{range .EntryInfos}}
+      {{executeTemplateForEntry .}}
+    {{end}}
+</section>
+</component>`
+
+	return t
+}


### PR DESCRIPTION
There is now a subpackage inside of exporter called document. This initial
refactor started with the allergy entry where a view model for allergy was
created with the original allergy model embedded in it. Then, the cat1 template
for allergy was added to the view model so that the view model could represent
itself in a cat1 form.