### PR TITLE
Change Makefile to run go-bindata with the -no-compress option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 build:
-	go-bindata -o exporter/templates.go -pkg exporter --prefix "exporter/" exporter/templates/*/*/*.xml exporter/hqmf_template_oid_map.json exporter/hqmf_qrda_oids.json exporter/hqmf_qrda_oids_r3_1.json
+	go-bindata -no-compress -o exporter/templates.go -pkg exporter --prefix "exporter/" exporter/templates/*/*/*.xml exporter/hqmf_template_oid_map.json exporter/hqmf_qrda_oids.json exporter/hqmf_qrda_oids_r3_1.json
 
 debug:
-	go-bindata -o exporter/templates.go -pkg exporter --debug --prefix "exporter/" exporter/templates/*/*/*.xml exporter/hqmf_template_oid_map.json exporter/hqmf_qrda_oids.json exporter/hqmf_qrda_oids_r3_1.json
+	go-bindata -no-compress -o exporter/templates.go -pkg exporter --debug --prefix "exporter/" exporter/templates/*/*/*.xml exporter/hqmf_template_oid_map.json exporter/hqmf_qrda_oids.json exporter/hqmf_qrda_oids_r3_1.json
 
 # fake out clean and install
 clean:


### PR DESCRIPTION
After doing an initial benchmark on the GenerateCat1 function, 50% of the
garbage created is because go-bindata gzips the templates before putting
them into templates.go and therefore has to unzip them before they can be
used. This happens on every call to any template. Simply giving go-bindata
the `-no-compress` option stops this and instantly decreases our memory
usage by about 62%. This is also helpful on computation, because 50% of cpu
time was spent collecting garbage.