### PR TITLE
Add export template for R3.1 Diagnosis

### DIFF
--- a/exporter/cat1_view_helper.go
+++ b/exporter/cat1_view_helper.go
@@ -230,6 +230,14 @@ func hasLaterality(l models.Laterality) bool {
 	return l != models.Laterality{}
 }
 
+func hasAnatomicalLocation(anatomicalLocation models.AnatomicalLocation) bool {
+	return anatomicalLocation != models.AnatomicalLocation{}
+}
+
+func hasSeverity(severity models.Severity) bool {
+	return severity != models.Severity{}
+}
+
 func codeDisplayAttributeIsCodes(attribute string) bool {
 	return attribute == "codes"
 }

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -51,6 +51,8 @@ func exporterFuncMap(cat1Template *template.Template, vsMap models.ValueSetMap) 
 		"codeDisplayAttributeIsCodes":                codeDisplayAttributeIsCodes,
 		"hasPreferredCode":                           hasPreferredCode,
 		"hasLaterality":                              hasLaterality,
+		"hasAnatomicalLocation":                      hasAnatomicalLocation,
+		"hasSeverity":                                hasSeverity,
 		"codeDisplayWithPreferredCode":               vsMap.CodeDisplayWithPreferredCode,
 		"codeDisplayWithPreferredCodeForField":  	  vsMap.CodeDisplayWithPreferredCodeForField,
 		"codeDisplayWithPreferredCodeForResultValue": vsMap.CodeDisplayWithPreferredCodeForResultValue,

--- a/exporter/templates.go
+++ b/exporter/templates.go
@@ -63,6 +63,7 @@
 // exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.103.xml
 // exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.105.xml
 // exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.12.xml
+// exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml
 // exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.140.xml
 // exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.17.xml
 // exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.18.xml
@@ -171,7 +172,7 @@ func templatesCat1R3_Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1493311295, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -201,7 +202,7 @@ func templatesCat1R3_216840111388310202431Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.1.xml", size: 670, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.1.xml", size: 670, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -232,7 +233,7 @@ func templatesCat1R3_21684011138831020243103Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -315,7 +316,7 @@ func templatesCat1R3_21684011138831020243105Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3123, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3123, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -388,7 +389,7 @@ func templatesCat1R3_2168401113883102024311Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.11.xml", size: 2802, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.11.xml", size: 2802, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -452,7 +453,7 @@ func templatesCat1R3_2168401113883102024312Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2090, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2090, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -507,7 +508,7 @@ func templatesCat1R3_2168401113883102024313Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.13.xml", size: 1702, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.13.xml", size: 1702, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -561,7 +562,7 @@ func templatesCat1R3_2168401113883102024314Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.14.xml", size: 1733, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.14.xml", size: 1733, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -605,7 +606,7 @@ func templatesCat1R3_2168401113883102024317Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1322, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1322, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -645,7 +646,7 @@ func templatesCat1R3_2168401113883102024318Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1217, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1217, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -693,7 +694,7 @@ func templatesCat1R3_216840111388310202432Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1283, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1283, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -732,7 +733,7 @@ func templatesCat1R3_2168401113883102024322Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.22.xml", size: 896, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.22.xml", size: 896, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -814,7 +815,7 @@ func templatesCat1R3_2168401113883102024323Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.23.xml", size: 3053, mode: os.FileMode(420), modTime: time.Unix(1496259463, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.23.xml", size: 3053, mode: os.FileMode(420), modTime: time.Unix(1496406122, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -854,7 +855,7 @@ func templatesCat1R3_2168401113883102024326Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1089, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1089, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -897,7 +898,7 @@ func templatesCat1R3_216840111388310202433Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1108, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1108, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -936,7 +937,7 @@ func templatesCat1R3_2168401113883102024331Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1025, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1025, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -972,7 +973,7 @@ func templatesCat1R3_2168401113883102024332Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1010,7 +1011,7 @@ func templatesCat1R3_2168401113883102024337Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.37.xml", size: 995, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.37.xml", size: 995, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1046,7 +1047,7 @@ func templatesCat1R3_2168401113883102024338Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.38.xml", size: 927, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.38.xml", size: 927, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1092,7 +1093,7 @@ func templatesCat1R3_216840111388310202434Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1243, mode: os.FileMode(420), modTime: time.Unix(1495816544, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1243, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1153,7 +1154,7 @@ func templatesCat1R3_2168401113883102024341Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1985, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1985, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1207,7 +1208,7 @@ func templatesCat1R3_2168401113883102024342Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1897, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1897, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1247,7 +1248,7 @@ func templatesCat1R3_2168401113883102024343Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1186, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1186, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1288,7 +1289,7 @@ func templatesCat1R3_2168401113883102024344Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1238, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1238, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1330,7 +1331,7 @@ func templatesCat1R3_2168401113883102024345Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1184, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1184, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1376,7 +1377,7 @@ func templatesCat1R3_2168401113883102024346Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1230, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1230, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1439,7 +1440,7 @@ func templatesCat1R3_2168401113883102024347Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2194, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2194, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1469,7 +1470,7 @@ func templatesCat1R3_2168401113883102024351Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1490279391, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1501,7 +1502,7 @@ func templatesCat1R3_2168401113883102024354Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1535,7 +1536,7 @@ func templatesCat1R3_2168401113883102024355Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1571,7 +1572,7 @@ func templatesCat1R3_2168401113883102024359Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1058, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1058, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1623,7 +1624,7 @@ func templatesCat1R3_2168401113883102024362Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1706, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1706, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1660,7 +1661,7 @@ func templatesCat1R3_2168401113883102024363Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1727,7 +1728,7 @@ func templatesCat1R3_2168401113883102024364Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.64.xml", size: 2554, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.64.xml", size: 2554, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1764,7 +1765,7 @@ func templatesCat1R3_2168401113883102024369Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1027, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1027, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1811,7 +1812,7 @@ func templatesCat1R3_216840111388310202437Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1505, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1505, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1846,7 +1847,7 @@ func templatesCat1R3_2168401113883102024376Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.76.xml", size: 908, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.76.xml", size: 908, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1883,7 +1884,7 @@ func templatesCat1R3_2168401113883102024381Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1004, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1004, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1920,7 +1921,7 @@ func templatesCat1R3_2168401113883102024382Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.82.xml", size: 997, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.82.xml", size: 997, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1994,7 +1995,7 @@ func templatesCat1R3_216840111388310202439Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.9.xml", size: 2659, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.9.xml", size: 2659, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2020,7 +2021,7 @@ func templatesCat1R3_addressXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2068,7 +2069,7 @@ func templatesCat1R3_authorXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2107,7 +2108,7 @@ func templatesCat1R3_codeXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_code.xml", size: 1111, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_code.xml", size: 1111, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2133,7 +2134,7 @@ func templatesCat1R3_fulfillsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_fulfills.xml", size: 401, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_fulfills.xml", size: 401, mode: os.FileMode(420), modTime: time.Unix(1488811579, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2151,7 +2152,7 @@ func templatesCat1R3_idXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1480703844, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2233,7 +2234,7 @@ func templatesCat1R3_measuresXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1489764643, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2263,7 +2264,7 @@ func templatesCat1R3_medication_detailsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2302,7 +2303,7 @@ func templatesCat1R3_medication_dispenseXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1493239144, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1490279391, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2325,7 +2326,7 @@ func templatesCat1R3_ordinalityXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2356,7 +2357,7 @@ func templatesCat1R3_organizationXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2392,7 +2393,7 @@ func templatesCat1R3_patient_dataXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_patient_data.xml", size: 622, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_patient_data.xml", size: 622, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2466,7 +2467,7 @@ func templatesCat1R3_providersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_providers.xml", size: 2078, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_providers.xml", size: 2078, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2501,7 +2502,7 @@ func templatesCat1R3_reasonXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2583,7 +2584,7 @@ func templatesCat1R3_record_targetXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2631,7 +2632,7 @@ func templatesCat1R3_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_reporting_parameters.xml", size: 1356, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_reporting_parameters.xml", size: 1356, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2663,7 +2664,7 @@ func templatesCat1R3_result_valueXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2681,7 +2682,7 @@ func templatesCat1R3_telecomXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2882,7 +2883,7 @@ func templatesCat1R3Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/cat1.xml", size: 6820, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/cat1.xml", size: 6820, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2899,7 +2900,7 @@ func templatesCat1R3_1_Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2929,7 +2930,7 @@ func templatesCat1R3_1_216840111388310202431Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.1.xml", size: 670, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.1.xml", size: 670, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2960,7 +2961,7 @@ func templatesCat1R3_1_21684011138831020243103Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3043,7 +3044,7 @@ func templatesCat1R3_1_21684011138831020243105Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3124, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3124, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3107,7 +3108,93 @@ func templatesCat1R3_1_2168401113883102024312Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2090, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2090, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
+var _templatesCat1R3_1_21684011138831020243135Xml = []byte(`<entry>
+  <act classCode="ACT" moodCode="EVN">
+    <!-- Conforms to C-CDA 2.1 Problem Concern Act (V3) -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+    <!-- Diagnosis Concern Act -->
+    <templateId root="2.16.840.1.113883.10.20.24.3.137" />
+    <id root="{{newRandom}}" />
+    <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
+    <statusCode code="active" />
+    <effectiveTime>
+      <low {{valueOrNullFlavor .EntrySection.Entry.StartTime}} />
+    </effectiveTime>
+    <entryRelationship typeCode="SUBJ">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Conforms to C-CDA R2.1 Problem Observation (V3) -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+        <!-- Diagnosis template -->
+        <templateId root="2.16.840.1.113883.10.20.24.3.135" />
+        <id root="1.3.6.1.4.1.115" extension="{{.EntrySection.Entry.ObjectIdentifier.ID}}" />
+        <code code="29308-4" codeSystem="2.16.840.1.113883.6.1">
+          <translation code="282291009" codeSystem="2.16.840.1.113883.6.96"/>
+        </code>
+        <statusCode code="completed" />
+        <effectiveTime>
+          <!-- Attribute: onset datetime -->
+          <low {{valueOrNullFlavor .EntrySection.Entry.StartTime}} />
+          <!-- Attribute: abatement datetime -->
+          <high {{valueOrNullFlavor .EntrySection.Entry.EndTime}} />
+        </effectiveTime>
+        {{template "_code.xml" codeDisplayWithPreferredCode .EntrySection.Entry .EntrySection.Entry.Coded .MapDataCriteria "entryCode"}}
+        {{if hasLaterality .EntrySection.Laterality}}
+          <targetSiteCode code="{{.EntrySection.Laterality.Code}}"
+                          codeSystem="{{oidForCodeSystem .EntrySection.Laterality.CodeSystem}}"
+                          {{if .EntrySection.Laterality.Title}}
+                            displayName="{{.EntrySection.Laterality.Title}}"
+                          {{end}}
+                          sdtc:valueSet="{{oidForCode .EntrySection.Laterality.CodedConcept (index .MapDataCriteria.FieldOids "LATERALITY")}}"
+          />
+        {{end}}
+        {{if hasAnatomicalLocation .EntrySection.AnatomicalLocation}}
+          <targetSiteCode code="{{.EntrySection.AnatomicalLocation.Code}}"
+                          codeSystem="{{oidForCodeSystem .EntrySection.AnatomicalLocation.CodeSystem}}"
+                          {{if .EntrySection.AnatomicalLocation.Title}}
+                            displayName="{{.EntrySection.AnatomicalLocation.Title}}"
+                          {{end}}
+                          sdtc:valueSet="{{oidForCode .EntrySection.AnatomicalLocation.CodedConcept (index .MapDataCriteria.FieldOids "ANATOMICAL_LOCATION_SITE")}}"
+          />
+        {{end}}
+        {{if hasSeverity .EntrySection.Severity}}
+          <entryRelationship typeCode="REFR">
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.8" extension="2014-06-09" />
+              <code code="SEV" codeSystem="2.16.840.1.113883.5.4" />
+              <statusCode code="completed" />
+              <value xsi:type="CD"
+                     code="{{.EntrySection.Severity.Code}}"
+                     codeSystem="{{oidForCodeSystem .EntrySection.Severity.CodeSystem}}"
+                     {{if .EntrySection.Severity.Title}}
+                       displayName="{{.EntrySection.Severity.Title}}"
+                     {{end}}
+                     sdtc:valueSet="{{oidForCode .EntrySection.Severity.CodedConcept (index .MapDataCriteria.FieldOids "SEVERITY")}}"
+              />
+            </observation>
+          </entryRelationship>
+        {{end}}
+      </observation>
+    </entryRelationship>
+  </act>
+</entry>
+`)
+
+func templatesCat1R3_1_21684011138831020243135XmlBytes() ([]byte, error) {
+	return _templatesCat1R3_1_21684011138831020243135Xml, nil
+}
+
+func templatesCat1R3_1_21684011138831020243135Xml() (*asset, error) {
+	bytes, err := templatesCat1R3_1_21684011138831020243135XmlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml", size: 3771, mode: os.FileMode(420), modTime: time.Unix(1496406220, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3162,7 +3249,7 @@ func templatesCat1R3_1_21684011138831020243140Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.140.xml", size: 1918, mode: os.FileMode(420), modTime: time.Unix(1496264068, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.140.xml", size: 1918, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3206,7 +3293,7 @@ func templatesCat1R3_1_2168401113883102024317Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1322, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1322, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3246,7 +3333,7 @@ func templatesCat1R3_1_2168401113883102024318Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1217, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1217, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3294,7 +3381,7 @@ func templatesCat1R3_1_216840111388310202432Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1282, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1282, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3340,7 +3427,7 @@ func templatesCat1R3_1_2168401113883102024322Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.22.xml", size: 1359, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.22.xml", size: 1359, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3467,7 +3554,7 @@ func templatesCat1R3_1_2168401113883102024323Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.23.xml", size: 5687, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.23.xml", size: 5687, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3507,7 +3594,7 @@ func templatesCat1R3_1_2168401113883102024326Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1089, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1089, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3550,7 +3637,7 @@ func templatesCat1R3_1_216840111388310202433Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1107, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1107, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3590,7 +3677,7 @@ func templatesCat1R3_1_2168401113883102024331Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1083, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1083, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3626,7 +3713,7 @@ func templatesCat1R3_1_2168401113883102024332Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3664,7 +3751,7 @@ func templatesCat1R3_1_2168401113883102024337Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.37.xml", size: 994, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.37.xml", size: 994, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3701,7 +3788,7 @@ func templatesCat1R3_1_2168401113883102024338Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.38.xml", size: 980, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.38.xml", size: 980, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3752,7 +3839,7 @@ func templatesCat1R3_1_216840111388310202434Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1277, mode: os.FileMode(420), modTime: time.Unix(1496333465, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1277, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3812,7 +3899,7 @@ func templatesCat1R3_1_2168401113883102024341Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1910, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1910, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3866,7 +3953,7 @@ func templatesCat1R3_1_2168401113883102024342Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1897, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1897, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3906,7 +3993,7 @@ func templatesCat1R3_1_2168401113883102024343Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1186, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1186, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3947,7 +4034,7 @@ func templatesCat1R3_1_2168401113883102024344Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1238, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1238, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3998,7 +4085,7 @@ func templatesCat1R3_1_2168401113883102024345Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1702, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1702, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4044,7 +4131,7 @@ func templatesCat1R3_1_2168401113883102024346Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1230, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1230, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4107,7 +4194,7 @@ func templatesCat1R3_1_2168401113883102024347Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2194, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2194, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4137,7 +4224,7 @@ func templatesCat1R3_1_2168401113883102024351Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1490279391, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4169,7 +4256,7 @@ func templatesCat1R3_1_2168401113883102024354Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4203,7 +4290,7 @@ func templatesCat1R3_1_2168401113883102024355Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4239,7 +4326,7 @@ func templatesCat1R3_1_2168401113883102024359Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1058, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1058, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4291,7 +4378,7 @@ func templatesCat1R3_1_2168401113883102024362Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1706, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1706, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4328,7 +4415,7 @@ func templatesCat1R3_1_2168401113883102024363Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1011, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4395,7 +4482,7 @@ func templatesCat1R3_1_2168401113883102024364Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.64.xml", size: 2554, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.64.xml", size: 2554, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4432,7 +4519,7 @@ func templatesCat1R3_1_2168401113883102024369Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1027, mode: os.FileMode(420), modTime: time.Unix(1495114915, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1027, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4479,7 +4566,7 @@ func templatesCat1R3_1_216840111388310202437Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1519, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1519, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4526,7 +4613,7 @@ func templatesCat1R3_1_2168401113883102024381Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1517, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1517, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4573,7 +4660,7 @@ func templatesCat1R3_1_2168401113883102024382Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.82.xml", size: 1499, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.82.xml", size: 1499, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4631,7 +4718,7 @@ func templatesCat1R3_1_216840111388310202439Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.9.xml", size: 1787, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.9.xml", size: 1787, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4657,7 +4744,7 @@ func templatesCat1R3_1_addressXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4705,7 +4792,7 @@ func templatesCat1R3_1_authorXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4744,7 +4831,7 @@ func templatesCat1R3_1_codeXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_code.xml", size: 1111, mode: os.FileMode(420), modTime: time.Unix(1496333304, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_code.xml", size: 1111, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4770,7 +4857,7 @@ func templatesCat1R3_1_fulfillsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_fulfills.xml", size: 401, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_fulfills.xml", size: 401, mode: os.FileMode(420), modTime: time.Unix(1489590408, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4788,7 +4875,7 @@ func templatesCat1R3_1_idXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4870,7 +4957,7 @@ func templatesCat1R3_1_measuresXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1489764643, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4900,7 +4987,7 @@ func templatesCat1R3_1_medication_detailsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4939,7 +5026,7 @@ func templatesCat1R3_1_medication_dispenseXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1490279391, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4962,7 +5049,7 @@ func templatesCat1R3_1_ordinalityXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4993,7 +5080,7 @@ func templatesCat1R3_1_organizationXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5030,7 +5117,7 @@ func templatesCat1R3_1_patient_dataXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_patient_data.xml", size: 623, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_patient_data.xml", size: 623, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5104,7 +5191,7 @@ func templatesCat1R3_1_providersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_providers.xml", size: 2078, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_providers.xml", size: 2078, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5139,7 +5226,7 @@ func templatesCat1R3_1_reasonXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5221,7 +5308,7 @@ func templatesCat1R3_1_record_targetXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5266,7 +5353,7 @@ func templatesCat1R3_1_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_reporting_parameters.xml", size: 1225, mode: os.FileMode(420), modTime: time.Unix(1496333465, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_reporting_parameters.xml", size: 1225, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5298,7 +5385,7 @@ func templatesCat1R3_1_result_valueXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_result_value.xml", size: 671, mode: os.FileMode(420), modTime: time.Unix(1496333465, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_result_value.xml", size: 671, mode: os.FileMode(420), modTime: time.Unix(1494443231, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5316,7 +5403,7 @@ func templatesCat1R3_1_telecomXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1475845670, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5520,7 +5607,7 @@ func templatesCat1R3_1Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/cat1.xml", size: 6885, mode: os.FileMode(420), modTime: time.Unix(1496251069, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/cat1.xml", size: 6885, mode: os.FileMode(420), modTime: time.Unix(1496406124, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6207,7 +6294,7 @@ func hqmf_template_oid_mapJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_template_oid_map.json", size: 20534, mode: os.FileMode(420), modTime: time.Unix(1494432774, 0)}
+	info := bindataFileInfo{name: "hqmf_template_oid_map.json", size: 20534, mode: os.FileMode(420), modTime: time.Unix(1460652616, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7684,7 +7771,7 @@ func hqmf_qrda_oidsJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_qrda_oids.json", size: 43927, mode: os.FileMode(420), modTime: time.Unix(1494432774, 0)}
+	info := bindataFileInfo{name: "hqmf_qrda_oids.json", size: 43927, mode: os.FileMode(420), modTime: time.Unix(1490280471, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7910,7 +7997,7 @@ func hqmf_qrda_oids_r3_1Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_qrda_oids_r3_1.json", size: 5727, mode: os.FileMode(420), modTime: time.Unix(1494432774, 0)}
+	info := bindataFileInfo{name: "hqmf_qrda_oids_r3_1.json", size: 5727, mode: os.FileMode(420), modTime: time.Unix(1488811577, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8030,6 +8117,7 @@ var _bindata = map[string]func() (*asset, error){
 	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.103.xml": templatesCat1R3_1_21684011138831020243103Xml,
 	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.105.xml": templatesCat1R3_1_21684011138831020243105Xml,
 	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.12.xml": templatesCat1R3_1_2168401113883102024312Xml,
+	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml": templatesCat1R3_1_21684011138831020243135Xml,
 	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.140.xml": templatesCat1R3_1_21684011138831020243140Xml,
 	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.17.xml": templatesCat1R3_1_2168401113883102024317Xml,
 	"templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.18.xml": templatesCat1R3_1_2168401113883102024318Xml,
@@ -8196,6 +8284,7 @@ var _bintree = &bintree{nil, map[string]*bintree{
 				"_2.16.840.1.113883.10.20.24.3.103.xml": &bintree{templatesCat1R3_1_21684011138831020243103Xml, map[string]*bintree{}},
 				"_2.16.840.1.113883.10.20.24.3.105.xml": &bintree{templatesCat1R3_1_21684011138831020243105Xml, map[string]*bintree{}},
 				"_2.16.840.1.113883.10.20.24.3.12.xml": &bintree{templatesCat1R3_1_2168401113883102024312Xml, map[string]*bintree{}},
+				"_2.16.840.1.113883.10.20.24.3.135.xml": &bintree{templatesCat1R3_1_21684011138831020243135Xml, map[string]*bintree{}},
 				"_2.16.840.1.113883.10.20.24.3.140.xml": &bintree{templatesCat1R3_1_21684011138831020243140Xml, map[string]*bintree{}},
 				"_2.16.840.1.113883.10.20.24.3.17.xml": &bintree{templatesCat1R3_1_2168401113883102024317Xml, map[string]*bintree{}},
 				"_2.16.840.1.113883.10.20.24.3.18.xml": &bintree{templatesCat1R3_1_2168401113883102024318Xml, map[string]*bintree{}},

--- a/exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml
+++ b/exporter/templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml
@@ -1,0 +1,69 @@
+<entry>
+  <act classCode="ACT" moodCode="EVN">
+    <!-- Conforms to C-CDA 2.1 Problem Concern Act (V3) -->
+    <templateId root="2.16.840.1.113883.10.20.22.4.3" extension="2015-08-01" />
+    <!-- Diagnosis Concern Act -->
+    <templateId root="2.16.840.1.113883.10.20.24.3.137" />
+    <id root="{{newRandom}}" />
+    <code code="CONC" codeSystem="2.16.840.1.113883.5.6" displayName="Concern" />
+    <statusCode code="active" />
+    <effectiveTime>
+      <low {{valueOrNullFlavor .EntrySection.Entry.StartTime}} />
+    </effectiveTime>
+    <entryRelationship typeCode="SUBJ">
+      <observation classCode="OBS" moodCode="EVN">
+        <!-- Conforms to C-CDA R2.1 Problem Observation (V3) -->
+        <templateId root="2.16.840.1.113883.10.20.22.4.4" extension="2015-08-01" />
+        <!-- Diagnosis template -->
+        <templateId root="2.16.840.1.113883.10.20.24.3.135" />
+        <id root="1.3.6.1.4.1.115" extension="{{.EntrySection.Entry.ObjectIdentifier.ID}}" />
+        <code code="29308-4" codeSystem="2.16.840.1.113883.6.1">
+          <translation code="282291009" codeSystem="2.16.840.1.113883.6.96"/>
+        </code>
+        <statusCode code="completed" />
+        <effectiveTime>
+          <!-- Attribute: onset datetime -->
+          <low {{valueOrNullFlavor .EntrySection.Entry.StartTime}} />
+          <!-- Attribute: abatement datetime -->
+          <high {{valueOrNullFlavor .EntrySection.Entry.EndTime}} />
+        </effectiveTime>
+        {{template "_code.xml" codeDisplayWithPreferredCode .EntrySection.Entry .EntrySection.Entry.Coded .MapDataCriteria "entryCode"}}
+        {{if hasLaterality .EntrySection.Laterality}}
+          <targetSiteCode code="{{.EntrySection.Laterality.Code}}"
+                          codeSystem="{{oidForCodeSystem .EntrySection.Laterality.CodeSystem}}"
+                          {{if .EntrySection.Laterality.Title}}
+                            displayName="{{.EntrySection.Laterality.Title}}"
+                          {{end}}
+                          sdtc:valueSet="{{oidForCode .EntrySection.Laterality.CodedConcept (index .MapDataCriteria.FieldOids "LATERALITY")}}"
+          />
+        {{end}}
+        {{if hasAnatomicalLocation .EntrySection.AnatomicalLocation}}
+          <targetSiteCode code="{{.EntrySection.AnatomicalLocation.Code}}"
+                          codeSystem="{{oidForCodeSystem .EntrySection.AnatomicalLocation.CodeSystem}}"
+                          {{if .EntrySection.AnatomicalLocation.Title}}
+                            displayName="{{.EntrySection.AnatomicalLocation.Title}}"
+                          {{end}}
+                          sdtc:valueSet="{{oidForCode .EntrySection.AnatomicalLocation.CodedConcept (index .MapDataCriteria.FieldOids "ANATOMICAL_LOCATION_SITE")}}"
+          />
+        {{end}}
+        {{if hasSeverity .EntrySection.Severity}}
+          <entryRelationship typeCode="REFR">
+            <observation classCode="OBS" moodCode="EVN">
+              <templateId root="2.16.840.1.113883.10.20.22.4.8" extension="2014-06-09" />
+              <code code="SEV" codeSystem="2.16.840.1.113883.5.4" />
+              <statusCode code="completed" />
+              <value xsi:type="CD"
+                     code="{{.EntrySection.Severity.Code}}"
+                     codeSystem="{{oidForCodeSystem .EntrySection.Severity.CodeSystem}}"
+                     {{if .EntrySection.Severity.Title}}
+                       displayName="{{.EntrySection.Severity.Title}}"
+                     {{end}}
+                     sdtc:valueSet="{{oidForCode .EntrySection.Severity.CodedConcept (index .MapDataCriteria.FieldOids "SEVERITY")}}"
+              />
+            </observation>
+          </entryRelationship>
+        {{end}}
+      </observation>
+    </entryRelationship>
+  </act>
+</entry>

--- a/exporter/templates_test.go
+++ b/exporter/templates_test.go
@@ -876,7 +876,8 @@ func TestCareGoalTemplate(t *testing.T) {
 	assertXPath(t, xrn, "//entry/observation/effectiveTime/low", map[string]string{"value": "201505101500+0000"}, nil)
 }
 
-// This test will work once we have R3.1 export and testing fixed
+// The tests below will work once we have R3.1 export and testing fixed
+
 // In order to get the tests working, we need to make qrdaVersion a parameter to generateDataForTemplate and xmlRootNodeForQrdaOidWithData
 // func TestImmunizationAdministered(t *testing.T) {
 // 	qrdaOid := "2.16.840.1.113883.10.20.24.3.140"
@@ -891,6 +892,24 @@ func TestCareGoalTemplate(t *testing.T) {
 // 	assertXPath(t, xrn, "//entry/act/effectiveTime/low", map[string]string{"value": "201411101000+0000"}, nil)
 // 	assertXPath(t, xrn, "//entry/act/effectiveTime/high", map[string]string{"value": "201411101000+0000"}, nil)
 // 	assertXPath(t, xrn, "//entry/act/entryRelationship/substanceAdministration/consumable/manufacturedProduct/manufacturedMaterial/lotNumberText", nil, nil)
+// }
+
+// func TestDiagnosis(t *testing.T) {
+// 	qrdaOid := "2.16.840.1.113883.10.20.24.3.135"
+// 	dataCriteriaName := "diagnosis"
+// 	entryName := "diagnosis"
+
+// 	ei := generateDataForTemplate(dataCriteriaName, entryName, &models.Condition{})
+// 	xrn := xmlRootNodeForQrdaOidWithData(qrdaOid, ei)
+
+// 	assertXPath(t, xrn, "//entry/act", map[string]string{"classCode": "ACT", "moodCode": "EVN"}, nil)
+// 	assertXPath(t, xrn, "//entry/act/templateId[@root='2.16.840.1.113883.10.20.24.3.137']", nil, nil)
+// 	assertXPath(t, xrn, "//entry/act/effectiveTime/low", map[string]string{"value": "200305130800+0000"}, nil)
+
+// 	assertXPath(t, xrn, "//entry/act/entryRelationship/observation/templateId[@root='2.16.840.1.113883.10.20.24.3.135']", nil, nil)
+// 	assertXPath(t, xrn, "//entry/act/entryRelationship/observation/effectiveTime/low", map[string]string{"value": "200305130800+0000"}, nil)
+// 	assertXPath(t, xrn, "//entry/act/entryRelationship/observation/effectiveTime/high[@nullFlavor='UNK']", nil, nil)
+// 	assertXPath(t, xrn, "//entry/act/entryRelationship/observation/targetSiteCode", map[string]string{"code": "24028007", "codeSystem": "2.16.840.1.113883.6.96", "displayName": "Right"}, nil)
 // }
 
 // - - - - - - - - //

--- a/fixtures/data_criteria/diagnosis.json
+++ b/fixtures/data_criteria/diagnosis.json
@@ -1,0 +1,19 @@
+{
+    "title": "Unilateral Amputation Below or Above Knee, Unspecified Laterality",
+    "description": "Diagnosis: Unilateral Amputation Below or Above Knee, Unspecified Laterality",
+    "code_list_id": "2.16.840.1.113883.3.464.1003.113.12.1059",
+    "type": "conditions",
+    "definition": "diagnosis",
+    "hard_status": false,
+    "negation": false,
+    "source_data_criteria": "prefix_9c9d8815_dc39_40e4_9897_507fd28d64cb_9a655be4_4072_4d34_9e13_fccc6a603231_source",
+    "variable": false,
+    "field_values": {
+        "ANATOMICAL_LOCATION_SITE": {
+            "type": "CD",
+            "code_list_id": "2.16.840.1.113883.3.464.1003.122.12.1036",
+            "title": "Left Grouping Value Set"
+        }
+    },
+    "hqmf_oid": "2.16.840.1.113883.10.20.28.3.110"
+}

--- a/fixtures/entries/diagnosis.json
+++ b/fixtures/entries/diagnosis.json
@@ -1,0 +1,43 @@
+{
+    "anatomical_location": {
+        "code_system": "SNOMED-CT",
+        "code": "24028007",
+        "title": "Right"
+    },
+    "anatomical_target": null,
+    "causeOfDeath": null,
+    "codes": {
+        "ICD-10-CM": [
+            "Q72.20"
+        ],
+        "SNOMED-CT": [
+            "298049006"
+        ],
+        "ICD-9-CM": [
+            "V49.76"
+        ]
+    },
+    "description": "Diagnosis: Unilateral Amputation Below Or Above Knee, Unspecified Laterality",
+    "end_time": null,
+    "laterality": null,
+    "mood_code": "EVN",
+    "name": null,
+    "negationInd": null,
+    "negationReason": null,
+    "oid": "2.16.840.1.113883.10.20.28.3.110",
+    "ordinality": null,
+    "priority": null,
+    "reason": null,
+    "severity": null,
+    "specifics": null,
+    "start_time": 1052812800,
+    "status_code": {
+        "HL7 ActStatus": [
+            null
+        ]
+    },
+    "time": null,
+    "time_of_death": null,
+    "type": null,
+    "_type": "Condition"
+}

--- a/models/condition.go
+++ b/models/condition.go
@@ -3,15 +3,15 @@ package models
 // Condition encompasses anything that is wrong with a patient that's not a Diagnosis
 type Condition struct {
 	Entry              `bson:",inline"`
-	Type               string       `json:"type,omitempty"`
-	CauseOfDeath       bool         `json:"cause_of_death,omitempty"`
-	TimeOfDeath        *int64       `json:"time_of_death,omitempty"`
-	Priority           int64        `json:"priority,omitempty"`
-	Name               string       `json:"name,omitempty"`
-	Ordinality         Ordinality   `json:"ordinality,omitempty"`
-	Severity           Severity     `json:"severity,omitempty"`
-	Laterality         Laterality   `json:"laterality,omitempty"`
-	AnatomicalLocation CodedConcept `json:"anatomical_location,omitempty"`
+	Type               string             `json:"type,omitempty"`
+	CauseOfDeath       bool               `json:"cause_of_death,omitempty"`
+	TimeOfDeath        *int64             `json:"time_of_death,omitempty"`
+	Priority           int64              `json:"priority,omitempty"`
+	Name               string             `json:"name,omitempty"`
+	Ordinality         Ordinality         `json:"ordinality,omitempty"`
+	Severity           Severity           `json:"severity,omitempty"`
+	Laterality         Laterality         `json:"laterality,omitempty"`
+	AnatomicalLocation AnatomicalLocation `json:"anatomical_location,omitempty"`
 }
 
 type Ordinality struct {
@@ -25,6 +25,11 @@ type Severity struct {
 }
 
 type Laterality struct {
+	CodedConcept `bson:",inline"`
+	Title        string `json:"title,omitempty"`
+}
+
+type AnatomicalLocation struct {
 	CodedConcept `bson:",inline"`
 	Title        string `json:"title,omitempty"`
 }

--- a/models/hds.go
+++ b/models/hds.go
@@ -1833,6 +1833,23 @@ var hqmf_qrda_oids_r3_1 = []byte(`[
         "value_set_preferred": false
       }
     ]
+  },
+  {
+    "hqmf_name": "Diagnosis",
+    "hqmf_oid": "2.16.840.1.113883.10.20.28.3.110",
+    "qrda_name": "Diagnosis",
+    "qrda_oid": "2.16.840.1.113883.10.20.24.3.135",
+    "code_displays": [
+      {
+        "code_type": "entryCode",
+        "tag_name": "code",
+        "attribute": "",
+        "exclude_null_flavor": false,
+        "preferred_code_sets": ["LOINC", "SNOMED-CT", "ICD-9-CM", "ICD-10-CM"],
+        "code_set_required": false,
+        "value_set_preferred": false
+      }
+    ]
   }
 ]`)
 

--- a/models/hds.go
+++ b/models/hds.go
@@ -1842,10 +1842,10 @@ var hqmf_qrda_oids_r3_1 = []byte(`[
     "code_displays": [
       {
         "code_type": "entryCode",
-        "tag_name": "code",
+        "tag_name": "value",
         "attribute": "",
         "exclude_null_flavor": false,
-        "preferred_code_sets": ["LOINC", "SNOMED-CT", "ICD-9-CM", "ICD-10-CM"],
+        "preferred_code_sets": ["2.16.840.1.113883.3.88.12.3221.7.4"],
         "code_set_required": false,
         "value_set_preferred": false
       }


### PR DESCRIPTION
Note that the tests are not currently set up to handle R3.1, and so the test written for this template is commented out.