### PR TITLE
Add LoadMeasuresAndValueSets to library API

### DIFF
--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -67,18 +67,27 @@ func exporterFuncMap(cat1Template *template.Template, vsMap models.ValueSetMap) 
 	}
 }
 
-// GenerateCat1 generates a cat1 xml string for export
-func GenerateCat1(patient []byte, measures []byte, valueSets []byte, startDate int64, endDate int64, qrdaVersion string, cmsCompatibility bool) string {
+// Global Measure Data for a batch of patients
+var m []models.Measure
 
-	p := &models.Record{}
-	m := []models.Measure{}
-	vs := []models.ValueSet{}
+// Global Value Set Data for a batch of patients
+var vs []models.ValueSet
 
-	json.Unmarshal(patient, p)
+// Global ValueSetMap for a batch of patients
+var vsMap models.ValueSetMap
+
+func LoadMeasuresAndValueSets(measures []byte, valueSets []byte) {
 	json.Unmarshal(measures, &m)
 	json.Unmarshal(valueSets, &vs)
+	vsMap = models.NewValueSetMap(vs)
+}
 
-	vsMap := models.NewValueSetMap(vs)
+// GenerateCat1 generates a cat1 xml string for export
+func GenerateCat1(patient []byte, startDate int64, endDate int64, qrdaVersion string, cmsCompatibility bool) string {
+
+	p := &models.Record{}
+
+	json.Unmarshal(patient, p)
 
 	if qrdaVersion == "" {
 		qrdaVersion = "r3"

--- a/exporter/exporter_test.go
+++ b/exporter/exporter_test.go
@@ -16,5 +16,6 @@ func TestExport(t *testing.T) {
 
 	startDate := int64(1451606400)
 	endDate := int64(1483228799)
-	fmt.Print(GenerateCat1(fixtures.TestPatientDataAmi, measureData, fixtures.Cms9_26, startDate, endDate, "r3", true))
+	LoadMeasuresAndValueSets(measureData, fixtures.Cms9_26)
+	fmt.Print(GenerateCat1(fixtures.TestPatientDataAmi, startDate, endDate, "r3", true))
 }


### PR DESCRIPTION
This function is being added to avoid having to unmarshal the
measure and value set data every time a patient gets exported.
The usual use case is that many patients need to be exported
under the same measures with the same value sets.

This function unmarshals the measure and value set data into
structures the Go library uses to properly export the patients. This
way, the Go library can reuse these structures for all the patients
and take pressure off the GC.

This means that this function is expected to be called before any
calls to GenerateCat1 and to only be called once per need to change
the measure and value set data.