### PR TITLE
CCN NPI fixes

### DIFF
--- a/exporter/templates.go
+++ b/exporter/templates.go
@@ -2701,7 +2701,7 @@ func templatesCat1R3_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_reporting_parameters.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1499966804, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_reporting_parameters.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1500054277, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2844,16 +2844,9 @@ var _templatesCat1R3Cat1Xml = []byte(`<?xml version="1.0" encoding="utf-8"?>
     <author>
       <time value="{{timeNow}}"/>
       <assignedAuthor>
-        <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
         <!-- NPI -->
-        {{if .CMSCompatibility}}
-          {{range .Record.ProviderPerformances}}
-            {{range .Provider.CDAIdentifiers}}
-              {{if eq .Root "2.16.840.1.113883.4.6"}}
-                <id root="2.16.840.1.113883.4.6" extension="{{.Extension}}" />
-              {{end}}
-            {{end}}
-          {{end}}
+        {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.6" "1234567893" }}
+          <id root="2.16.840.1.113883.4.6" extension="{{.}}" />
         {{end}}
         <addr>
           <streetAddressLine>202 Burlington Rd.</streetAddressLine>
@@ -2872,9 +2865,11 @@ var _templatesCat1R3Cat1Xml = []byte(`<?xml version="1.0" encoding="utf-8"?>
     <custodian>
       <assignedCustodian>
         <representedCustodianOrganization>
-          <!-- HQR Only -->
           {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
-            <id root="2.16.840.1.113883.4.336" extension="800890"/>
+            <!-- HQR Only -->
+            {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.336" "800890" }}
+              <id root="2.16.840.1.113883.4.336" extension="{{.}}" />
+            {{end}}
           {{else}}
             <id root="2.16.840.1.113883.19.5"/>
           {{end}}
@@ -2952,7 +2947,7 @@ func templatesCat1R3Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/cat1.xml", size: 6822, mode: os.FileMode(420), modTime: time.Unix(1499966032, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/cat1.xml", size: 6701, mode: os.FileMode(420), modTime: time.Unix(1500054277, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5458,7 +5453,7 @@ func templatesCat1R3_1_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_reporting_parameters.xml", size: 1235, mode: os.FileMode(420), modTime: time.Unix(1499966791, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_reporting_parameters.xml", size: 1235, mode: os.FileMode(420), modTime: time.Unix(1500054277, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5603,18 +5598,10 @@ var _templatesCat1R3_1Cat1Xml = []byte(`<?xml version="1.0" encoding="utf-8"?>
     <author>
       <time value="{{timeNow}}"/>
       <assignedAuthor>
-        <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
         <!-- NPI -->
-        {{if .CMSCompatibility}}
-          {{range .Record.ProviderPerformances}}
-            {{range .Provider.CDAIdentifiers}}
-              {{if eq .Root "2.16.840.1.113883.4.6"}}
-                <id root="2.16.840.1.113883.4.6" extension="{{.Extension}}" />
-              {{end}}
-            {{end}}
-          {{end}}
+        {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.6" "1234567893" }}
+          <id root="2.16.840.1.113883.4.6" extension="{{.}}" />
         {{end}}
-        <id extension="FakeNPI" root="2.16.840.1.113883.4.6"/>
         <addr>
           <streetAddressLine>202 Burlington Rd.</streetAddressLine>
           <city>Bedford</city>
@@ -5632,12 +5619,14 @@ var _templatesCat1R3_1Cat1Xml = []byte(`<?xml version="1.0" encoding="utf-8"?>
     <custodian>
       <assignedCustodian>
         <representedCustodianOrganization>
-        <!-- HQR Only -->
-        {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
-          <id root="2.16.840.1.113883.4.336" extension="800890"/>
-        {{else}}
-          <id root="2.16.840.1.113883.19.5"/>
-        {{end}}
+          {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
+            <!-- HQR Only -->
+            {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.336" "800890" }}
+              <id root="2.16.840.1.113883.4.336" extension="{{.}}" />
+            {{end}}
+          {{else}}
+            <id root="2.16.840.1.113883.19.5"/>
+          {{end}}
           <name>Cypress Test Deck</name>
           <telecom use="WP" value="tel:(781)271-3000"/>
           <addr>
@@ -5712,7 +5701,7 @@ func templatesCat1R3_1Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/cat1.xml", size: 6887, mode: os.FileMode(420), modTime: time.Unix(1499966032, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/cat1.xml", size: 6715, mode: os.FileMode(420), modTime: time.Unix(1500054277, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8219,7 +8208,7 @@ func templatesCat1R4_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_reporting_parameters.xml", size: 1235, mode: os.FileMode(420), modTime: time.Unix(1499966086, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_reporting_parameters.xml", size: 1235, mode: os.FileMode(420), modTime: time.Unix(1500054277, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8364,18 +8353,10 @@ var _templatesCat1R4Cat1Xml = []byte(`<?xml version="1.0" encoding="utf-8"?>
     <author>
       <time value="{{timeNow}}"/>
       <assignedAuthor>
-        <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
         <!-- NPI -->
-        {{if .CMSCompatibility}}
-          {{range .Record.ProviderPerformances}}
-            {{range .Provider.CDAIdentifiers}}
-              {{if eq .Root "2.16.840.1.113883.4.6"}}
-                <id root="2.16.840.1.113883.4.6" extension="{{.Extension}}" />
-              {{end}}
-            {{end}}
-          {{end}}
+        {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.6" "1234567893" }}
+          <id root="2.16.840.1.113883.4.6" extension="{{.}}" />
         {{end}}
-        <id extension="FakeNPI" root="2.16.840.1.113883.4.6"/>
         <addr>
           <streetAddressLine>202 Burlington Rd.</streetAddressLine>
           <city>Bedford</city>
@@ -8393,12 +8374,14 @@ var _templatesCat1R4Cat1Xml = []byte(`<?xml version="1.0" encoding="utf-8"?>
     <custodian>
       <assignedCustodian>
         <representedCustodianOrganization>
-        <!-- HQR Only -->
-        {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
-          <id root="2.16.840.1.113883.4.336" extension="800890"/>
-        {{else}}
-          <id root="2.16.840.1.113883.19.5"/>
-        {{end}}
+          {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
+            <!-- HQR Only -->
+            {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.336" "800890" }}
+              <id root="2.16.840.1.113883.4.336" extension="{{.}}" />
+            {{end}}
+          {{else}}
+            <id root="2.16.840.1.113883.19.5"/>
+          {{end}}
           <name>Cypress Test Deck</name>
           <telecom use="WP" value="tel:(781)271-3000"/>
           <addr>
@@ -8473,7 +8456,7 @@ func templatesCat1R4Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/cat1.xml", size: 6887, mode: os.FileMode(420), modTime: time.Unix(1499966032, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/cat1.xml", size: 6715, mode: os.FileMode(420), modTime: time.Unix(1500054277, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/exporter/templates/cat1/r3/cat1.xml
+++ b/exporter/templates/cat1/r3/cat1.xml
@@ -86,16 +86,9 @@
     <author>
       <time value="{{timeNow}}"/>
       <assignedAuthor>
-        <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
         <!-- NPI -->
-        {{if .CMSCompatibility}}
-          {{range .Record.ProviderPerformances}}
-            {{range .Provider.CDAIdentifiers}}
-              {{if eq .Root "2.16.840.1.113883.4.6"}}
-                <id root="2.16.840.1.113883.4.6" extension="{{.Extension}}" />
-              {{end}}
-            {{end}}
-          {{end}}
+        {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.6" "1234567893" }}
+          <id root="2.16.840.1.113883.4.6" extension="{{.}}" />
         {{end}}
         <addr>
           <streetAddressLine>202 Burlington Rd.</streetAddressLine>
@@ -114,9 +107,11 @@
     <custodian>
       <assignedCustodian>
         <representedCustodianOrganization>
-          <!-- HQR Only -->
           {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
-            <id root="2.16.840.1.113883.4.336" extension="800890"/>
+            <!-- HQR Only -->
+            {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.336" "800890" }}
+              <id root="2.16.840.1.113883.4.336" extension="{{.}}" />
+            {{end}}
           {{else}}
             <id root="2.16.840.1.113883.19.5"/>
           {{end}}

--- a/exporter/templates/cat1/r3_1/cat1.xml
+++ b/exporter/templates/cat1/r3_1/cat1.xml
@@ -88,18 +88,10 @@
     <author>
       <time value="{{timeNow}}"/>
       <assignedAuthor>
-        <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
         <!-- NPI -->
-        {{if .CMSCompatibility}}
-          {{range .Record.ProviderPerformances}}
-            {{range .Provider.CDAIdentifiers}}
-              {{if eq .Root "2.16.840.1.113883.4.6"}}
-                <id root="2.16.840.1.113883.4.6" extension="{{.Extension}}" />
-              {{end}}
-            {{end}}
-          {{end}}
+        {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.6" "1234567893" }}
+          <id root="2.16.840.1.113883.4.6" extension="{{.}}" />
         {{end}}
-        <id extension="FakeNPI" root="2.16.840.1.113883.4.6"/>
         <addr>
           <streetAddressLine>202 Burlington Rd.</streetAddressLine>
           <city>Bedford</city>
@@ -117,12 +109,14 @@
     <custodian>
       <assignedCustodian>
         <representedCustodianOrganization>
-        <!-- HQR Only -->
-        {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
-          <id root="2.16.840.1.113883.4.336" extension="800890"/>
-        {{else}}
-          <id root="2.16.840.1.113883.19.5"/>
-        {{end}}
+          {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
+            <!-- HQR Only -->
+            {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.336" "800890" }}
+              <id root="2.16.840.1.113883.4.336" extension="{{.}}" />
+            {{end}}
+          {{else}}
+            <id root="2.16.840.1.113883.19.5"/>
+          {{end}}
           <name>Cypress Test Deck</name>
           <telecom use="WP" value="tel:(781)271-3000"/>
           <addr>

--- a/exporter/templates/cat1/r4/cat1.xml
+++ b/exporter/templates/cat1/r4/cat1.xml
@@ -88,18 +88,10 @@
     <author>
       <time value="{{timeNow}}"/>
       <assignedAuthor>
-        <!-- id extension="Cypress" root="2.16.840.1.113883.19.5"/ -->
         <!-- NPI -->
-        {{if .CMSCompatibility}}
-          {{range .Record.ProviderPerformances}}
-            {{range .Provider.CDAIdentifiers}}
-              {{if eq .Root "2.16.840.1.113883.4.6"}}
-                <id root="2.16.840.1.113883.4.6" extension="{{.Extension}}" />
-              {{end}}
-            {{end}}
-          {{end}}
+        {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.6" "1234567893" }}
+          <id root="2.16.840.1.113883.4.6" extension="{{.}}" />
         {{end}}
-        <id extension="FakeNPI" root="2.16.840.1.113883.4.6"/>
         <addr>
           <streetAddressLine>202 Burlington Rd.</streetAddressLine>
           <city>Bedford</city>
@@ -117,12 +109,14 @@
     <custodian>
       <assignedCustodian>
         <representedCustodianOrganization>
-        <!-- HQR Only -->
-        {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
-          <id root="2.16.840.1.113883.4.336" extension="800890"/>
-        {{else}}
-          <id root="2.16.840.1.113883.19.5"/>
-        {{end}}
+          {{if and .CMSCompatibility (eq .ReportingProgram "HQR_EHR")}}
+            <!-- HQR Only -->
+            {{range .Record.ProviderIdentifiersForRoot "2.16.840.1.113883.4.336" "800890" }}
+              <id root="2.16.840.1.113883.4.336" extension="{{.}}" />
+            {{end}}
+          {{else}}
+            <id root="2.16.840.1.113883.19.5"/>
+          {{end}}
           <name>Cypress Test Deck</name>
           <telecom use="WP" value="tel:(781)271-3000"/>
           <addr>

--- a/models/provider.go
+++ b/models/provider.go
@@ -13,3 +13,24 @@ type Provider struct {
 	Telecoms       []Telecom       `json:"telecoms,omitempty"`
 	CDAIdentifiers []CDAIdentifier `json:"cda_identifiers,omitempty"`
 }
+
+// IdentifierForRoot takes a Provider and a string identifying the root OID, and returns the extension for that OID
+func (prov *Provider) IdentifierForRoot(root string) string {
+	for _, identifier := range prov.CDAIdentifiers {
+		if identifier.Root == root {
+			return identifier.Extension
+		}
+	}
+	return ""
+}
+
+// IdentifiersForRoot applies IdentifierForRoot to a passed-in slice of Providers
+func IdentifiersForRoot(provs []Provider, root string) []string {
+	ids := []string{}
+	for _, provider := range provs {
+		if id := provider.IdentifierForRoot(root); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}

--- a/models/provider_performance.go
+++ b/models/provider_performance.go
@@ -10,3 +10,12 @@ type ProviderPerformance struct {
 func (pp *ProviderPerformance) GetEntry() *Entry {
 	return &pp.Entry
 }
+
+// GetProviders returns the Provider objects from a slice of ProviderPerformances
+func GetProviders(perfs []ProviderPerformance) []Provider {
+	provs := []Provider{}
+	for _, pp := range perfs {
+		provs = append(provs, pp.Provider)
+	}
+	return provs
+}

--- a/models/provider_performance_test.go
+++ b/models/provider_performance_test.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetProviders(t *testing.T) {
+	pps := []ProviderPerformance{
+		ProviderPerformance{
+			Provider: Provider{
+				CDAIdentifiers: []CDAIdentifier{
+					CDAIdentifier{
+						Root:      "test",
+						Extension: "value1",
+					},
+					CDAIdentifier{
+						Root:      "notvalid",
+						Extension: "notthisvalue",
+					},
+				},
+			},
+		},
+		ProviderPerformance{
+			Provider: Provider{
+				CDAIdentifiers: []CDAIdentifier{
+					CDAIdentifier{
+						Root:      "test",
+						Extension: "value2",
+					},
+					CDAIdentifier{
+						Root:      "notvalid",
+						Extension: "notthisvalueeither",
+					},
+				},
+			},
+		},
+	}
+
+	provs := GetProviders(pps)
+
+	assert.Equal(t, 2, len(provs))
+
+	ids := IdentifiersForRoot(provs, "test")
+
+	assert.Equal(t, 2, len(ids))
+	assert.Contains(t, ids, "value1")
+	assert.Contains(t, ids, "value2")
+}

--- a/models/record.go
+++ b/models/record.go
@@ -262,6 +262,16 @@ func (r *Record) EntryInfosForPatient(measures []Measure, vsMap map[string][]Cod
 	return entryInfos
 }
 
+// ProviderIdentifiersForRoot gets all the Extensions for a given Root, for the providers on a given record
+// def is a Default value, only passed back if there are no valid identifiers in the Record
+func (r Record) ProviderIdentifiersForRoot(root string, def string) []string {
+	ids := IdentifiersForRoot(GetProviders(r.ProviderPerformances), root)
+	if len(ids) == 0 && def != "" {
+		ids = append(ids, def)
+	}
+	return ids
+}
+
 // ResolveReference takes a Reference object, and finds the Entry that it refers to
 func (r *Record) ResolveReference(ref Reference) HasEntry {
 	switch ref.ReferencedType {

--- a/models/record_test.go
+++ b/models/record_test.go
@@ -62,3 +62,45 @@ func TestEntriesForDataCriteria(t *testing.T) {
 	// TODO: This test will have to change when we get a new export of CMS9v4a with all the HQMFOid fields filled.
 	assert.Equal(t, len(entries), 1)
 }
+
+func TestGetIdentifiersForRoot(t *testing.T) {
+	rec := Record{
+		ProviderPerformances: []ProviderPerformance{
+			ProviderPerformance{
+				Provider: Provider{
+					CDAIdentifiers: []CDAIdentifier{
+						CDAIdentifier{
+							Root:      "test",
+							Extension: "value1",
+						},
+						CDAIdentifier{
+							Root:      "notvalid",
+							Extension: "notthisvalue",
+						},
+					},
+				},
+			},
+			ProviderPerformance{
+				Provider: Provider{
+					CDAIdentifiers: []CDAIdentifier{
+						CDAIdentifier{
+							Root:      "test",
+							Extension: "value2",
+						},
+						CDAIdentifier{
+							Root:      "notvalid",
+							Extension: "notthisvalueeither",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	ids := rec.ProviderIdentifiersForRoot("test", "default")
+	assert.Equal(t, 2, len(ids))
+
+	ids = rec.ProviderIdentifiersForRoot("nonexistent", "default")
+	assert.Equal(t, 1, len(ids))
+	assert.Contains(t, ids, "default")
+}


### PR DESCRIPTION
Built a better system for adding CCNs/NPIs to Cat I headers. Basically, the system looks for the given `root` ID in the Provider Performances for a patient. If that's not found, it puts in the default.