### PR TITLE
Remove util checkerr

### DIFF
--- a/exporter/templates.go
+++ b/exporter/templates.go
@@ -231,7 +231,7 @@ func templatesCat1R3_Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1493311295, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -261,7 +261,7 @@ func templatesCat1R3_216840111388310202431Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.1.xml", size: 677, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.1.xml", size: 677, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -292,7 +292,7 @@ func templatesCat1R3_21684011138831020243103Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1494271976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -375,7 +375,7 @@ func templatesCat1R3_21684011138831020243105Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3130, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3130, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -448,7 +448,7 @@ func templatesCat1R3_2168401113883102024311Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.11.xml", size: 2807, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.11.xml", size: 2807, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -512,7 +512,7 @@ func templatesCat1R3_2168401113883102024312Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2097, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2097, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -567,7 +567,7 @@ func templatesCat1R3_2168401113883102024313Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.13.xml", size: 1702, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.13.xml", size: 1702, mode: os.FileMode(420), modTime: time.Unix(1494271976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -621,7 +621,7 @@ func templatesCat1R3_2168401113883102024314Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.14.xml", size: 1733, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.14.xml", size: 1733, mode: os.FileMode(420), modTime: time.Unix(1495114962, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -665,7 +665,7 @@ func templatesCat1R3_2168401113883102024317Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1323, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1323, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -705,7 +705,7 @@ func templatesCat1R3_2168401113883102024318Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1218, mode: os.FileMode(420), modTime: time.Unix(1498066845, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1218, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -753,7 +753,7 @@ func templatesCat1R3_216840111388310202432Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1290, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1290, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -792,7 +792,7 @@ func templatesCat1R3_2168401113883102024322Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.22.xml", size: 903, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.22.xml", size: 903, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -874,7 +874,7 @@ func templatesCat1R3_2168401113883102024323Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.23.xml", size: 3093, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.23.xml", size: 3093, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -915,7 +915,7 @@ func templatesCat1R3_2168401113883102024326Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1132, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1132, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -958,7 +958,7 @@ func templatesCat1R3_216840111388310202433Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1109, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1109, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -997,7 +997,7 @@ func templatesCat1R3_2168401113883102024331Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1030, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1030, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1033,7 +1033,7 @@ func templatesCat1R3_2168401113883102024332Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1071,7 +1071,7 @@ func templatesCat1R3_2168401113883102024337Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.37.xml", size: 996, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.37.xml", size: 996, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1107,7 +1107,7 @@ func templatesCat1R3_2168401113883102024338Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.38.xml", size: 928, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.38.xml", size: 928, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1153,7 +1153,7 @@ func templatesCat1R3_216840111388310202434Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1248, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1248, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1214,7 +1214,7 @@ func templatesCat1R3_2168401113883102024341Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1992, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1992, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1268,7 +1268,7 @@ func templatesCat1R3_2168401113883102024342Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1904, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1904, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1308,7 +1308,7 @@ func templatesCat1R3_2168401113883102024343Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1193, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1193, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1349,7 +1349,7 @@ func templatesCat1R3_2168401113883102024344Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1245, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1245, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1391,7 +1391,7 @@ func templatesCat1R3_2168401113883102024345Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1191, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1191, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1437,7 +1437,7 @@ func templatesCat1R3_2168401113883102024346Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1237, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1237, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1500,7 +1500,7 @@ func templatesCat1R3_2168401113883102024347Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2201, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2201, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1530,7 +1530,7 @@ func templatesCat1R3_2168401113883102024351Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1562,7 +1562,7 @@ func templatesCat1R3_2168401113883102024354Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1495114962, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1596,7 +1596,7 @@ func templatesCat1R3_2168401113883102024355Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494271976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1632,7 +1632,7 @@ func templatesCat1R3_2168401113883102024359Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1065, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1065, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1684,7 +1684,7 @@ func templatesCat1R3_2168401113883102024362Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1711, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1711, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1721,7 +1721,7 @@ func templatesCat1R3_2168401113883102024363Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1769,7 +1769,7 @@ func templatesCat1R3_2168401113883102024364Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.64.xml", size: 1567, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.64.xml", size: 1567, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1806,7 +1806,7 @@ func templatesCat1R3_2168401113883102024369Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1034, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1034, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1853,7 +1853,7 @@ func templatesCat1R3_216840111388310202437Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1506, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1506, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1888,7 +1888,7 @@ func templatesCat1R3_2168401113883102024376Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.76.xml", size: 915, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.76.xml", size: 915, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1925,7 +1925,7 @@ func templatesCat1R3_2168401113883102024381Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1004, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1004, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -1962,7 +1962,7 @@ func templatesCat1R3_2168401113883102024382Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.82.xml", size: 997, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.82.xml", size: 997, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2036,7 +2036,7 @@ func templatesCat1R3_216840111388310202439Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.9.xml", size: 2661, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_2.16.840.1.113883.10.20.24.3.9.xml", size: 2661, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2062,7 +2062,7 @@ func templatesCat1R3_addressXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2110,7 +2110,7 @@ func templatesCat1R3_authorXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1485284256, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2154,7 +2154,7 @@ func templatesCat1R3_codeXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_code.xml", size: 1337, mode: os.FileMode(420), modTime: time.Unix(1499962120, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_code.xml", size: 1337, mode: os.FileMode(420), modTime: time.Unix(1499956862, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2180,7 +2180,7 @@ func templatesCat1R3_fulfillsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_fulfills.xml", size: 424, mode: os.FileMode(420), modTime: time.Unix(1497455969, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_fulfills.xml", size: 424, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2198,7 +2198,7 @@ func templatesCat1R3_idXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2280,7 +2280,7 @@ func templatesCat1R3_measuresXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2310,7 +2310,7 @@ func templatesCat1R3_medication_detailsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1484235880, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2349,7 +2349,7 @@ func templatesCat1R3_medication_dispenseXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1493239144, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2372,7 +2372,7 @@ func templatesCat1R3_ordinalityXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1482262375, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2403,7 +2403,7 @@ func templatesCat1R3_organizationXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2439,7 +2439,7 @@ func templatesCat1R3_patient_dataXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_patient_data.xml", size: 622, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_patient_data.xml", size: 622, mode: os.FileMode(420), modTime: time.Unix(1497276824, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2522,7 +2522,7 @@ func templatesCat1R3_providersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_providers.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_providers.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2557,7 +2557,7 @@ func templatesCat1R3_reasonXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1482262375, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2639,7 +2639,7 @@ func templatesCat1R3_record_targetXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1497276824, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2687,7 +2687,7 @@ func templatesCat1R3_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_reporting_parameters.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1500062669, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_reporting_parameters.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1500037487, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2719,7 +2719,7 @@ func templatesCat1R3_result_valueXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1494271976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2754,7 +2754,7 @@ func templatesCat1R3_resultsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_results.xml", size: 972, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_results.xml", size: 972, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2772,7 +2772,7 @@ func templatesCat1R3_telecomXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2968,7 +2968,7 @@ func templatesCat1R3Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3/cat1.xml", size: 6769, mode: os.FileMode(420), modTime: time.Unix(1500393904, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3/cat1.xml", size: 6769, mode: os.FileMode(420), modTime: time.Unix(1500407832, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -2985,7 +2985,7 @@ func templatesCat1R3_1_Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3015,7 +3015,7 @@ func templatesCat1R3_1_216840111388310202431Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.1.xml", size: 677, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.1.xml", size: 677, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3046,7 +3046,7 @@ func templatesCat1R3_1_21684011138831020243103Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1495819396, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3129,7 +3129,7 @@ func templatesCat1R3_1_21684011138831020243105Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3131, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3131, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3198,7 +3198,7 @@ func templatesCat1R3_1_2168401113883102024312Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2402, mode: os.FileMode(420), modTime: time.Unix(1501692391, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2402, mode: os.FileMode(420), modTime: time.Unix(1501706195, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3284,7 +3284,7 @@ func templatesCat1R3_1_21684011138831020243135Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml", size: 3771, mode: os.FileMode(420), modTime: time.Unix(1497378362, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.135.xml", size: 3771, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3339,7 +3339,7 @@ func templatesCat1R3_1_21684011138831020243140Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.140.xml", size: 1919, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.140.xml", size: 1919, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3383,7 +3383,7 @@ func templatesCat1R3_1_2168401113883102024317Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1323, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1323, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3423,7 +3423,7 @@ func templatesCat1R3_1_2168401113883102024318Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1218, mode: os.FileMode(420), modTime: time.Unix(1498066845, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1218, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3471,7 +3471,7 @@ func templatesCat1R3_1_216840111388310202432Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1289, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1289, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3517,7 +3517,7 @@ func templatesCat1R3_1_2168401113883102024322Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.22.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.22.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3664,7 +3664,7 @@ func templatesCat1R3_1_2168401113883102024323Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.23.xml", size: 7814, mode: os.FileMode(420), modTime: time.Unix(1500936757, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.23.xml", size: 7814, mode: os.FileMode(420), modTime: time.Unix(1500921728, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3705,7 +3705,7 @@ func templatesCat1R3_1_2168401113883102024326Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1132, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.26.xml", size: 1132, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3748,7 +3748,7 @@ func templatesCat1R3_1_216840111388310202433Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1108, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1108, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3788,7 +3788,7 @@ func templatesCat1R3_1_2168401113883102024331Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1088, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1088, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3824,7 +3824,7 @@ func templatesCat1R3_1_2168401113883102024332Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3862,7 +3862,7 @@ func templatesCat1R3_1_2168401113883102024337Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.37.xml", size: 995, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.37.xml", size: 995, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3899,7 +3899,7 @@ func templatesCat1R3_1_2168401113883102024338Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.38.xml", size: 981, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.38.xml", size: 981, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -3948,7 +3948,7 @@ func templatesCat1R3_1_216840111388310202434Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1251, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1251, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4008,7 +4008,7 @@ func templatesCat1R3_1_2168401113883102024341Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1917, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1917, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4062,7 +4062,7 @@ func templatesCat1R3_1_2168401113883102024342Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1904, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1904, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4102,7 +4102,7 @@ func templatesCat1R3_1_2168401113883102024343Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1193, mode: os.FileMode(420), modTime: time.Unix(1501692391, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1193, mode: os.FileMode(420), modTime: time.Unix(1501706195, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4143,7 +4143,7 @@ func templatesCat1R3_1_2168401113883102024344Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1245, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1245, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4194,7 +4194,7 @@ func templatesCat1R3_1_2168401113883102024345Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1709, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1709, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4240,7 +4240,7 @@ func templatesCat1R3_1_2168401113883102024346Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1237, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1237, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4303,7 +4303,7 @@ func templatesCat1R3_1_2168401113883102024347Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2201, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2201, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4333,7 +4333,7 @@ func templatesCat1R3_1_2168401113883102024351Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4365,7 +4365,7 @@ func templatesCat1R3_1_2168401113883102024354Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1494516128, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1495114962, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4399,7 +4399,7 @@ func templatesCat1R3_1_2168401113883102024355Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494432834, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1494271976, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4435,7 +4435,7 @@ func templatesCat1R3_1_2168401113883102024359Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1065, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1065, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4487,7 +4487,7 @@ func templatesCat1R3_1_2168401113883102024362Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1711, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1711, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4524,7 +4524,7 @@ func templatesCat1R3_1_2168401113883102024363Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1500917575, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1500921728, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4572,7 +4572,7 @@ func templatesCat1R3_1_2168401113883102024364Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.64.xml", size: 1567, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.64.xml", size: 1567, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4609,7 +4609,7 @@ func templatesCat1R3_1_2168401113883102024369Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1034, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.69.xml", size: 1034, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4656,7 +4656,7 @@ func templatesCat1R3_1_216840111388310202437Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1520, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1520, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4703,7 +4703,7 @@ func templatesCat1R3_1_2168401113883102024381Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1517, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1517, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4750,7 +4750,7 @@ func templatesCat1R3_1_2168401113883102024382Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.82.xml", size: 1499, mode: os.FileMode(420), modTime: time.Unix(1496333470, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.82.xml", size: 1499, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4808,7 +4808,7 @@ func templatesCat1R3_1_216840111388310202439Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.9.xml", size: 1784, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_2.16.840.1.113883.10.20.24.3.9.xml", size: 1784, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4834,7 +4834,7 @@ func templatesCat1R3_1_addressXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4882,7 +4882,7 @@ func templatesCat1R3_1_authorXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1485284256, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4926,7 +4926,7 @@ func templatesCat1R3_1_codeXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_code.xml", size: 1337, mode: os.FileMode(420), modTime: time.Unix(1499962120, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_code.xml", size: 1337, mode: os.FileMode(420), modTime: time.Unix(1499956862, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4952,7 +4952,7 @@ func templatesCat1R3_1_fulfillsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_fulfills.xml", size: 424, mode: os.FileMode(420), modTime: time.Unix(1497455971, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_fulfills.xml", size: 424, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -4970,7 +4970,7 @@ func templatesCat1R3_1_idXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5052,7 +5052,7 @@ func templatesCat1R3_1_measuresXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_measures.xml", size: 2610, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5082,7 +5082,7 @@ func templatesCat1R3_1_medication_detailsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1484235880, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5121,7 +5121,7 @@ func templatesCat1R3_1_medication_dispenseXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5144,7 +5144,7 @@ func templatesCat1R3_1_ordinalityXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1482262375, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5175,7 +5175,7 @@ func templatesCat1R3_1_organizationXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5212,7 +5212,7 @@ func templatesCat1R3_1_patient_dataXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_patient_data.xml", size: 625, mode: os.FileMode(420), modTime: time.Unix(1500478348, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_patient_data.xml", size: 625, mode: os.FileMode(420), modTime: time.Unix(1500407832, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5295,7 +5295,7 @@ func templatesCat1R3_1_providersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_providers.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_providers.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5330,7 +5330,7 @@ func templatesCat1R3_1_reasonXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1482262375, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5412,7 +5412,7 @@ func templatesCat1R3_1_record_targetXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1500391152, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5460,7 +5460,7 @@ func templatesCat1R3_1_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_reporting_parameters.xml", size: 1373, mode: os.FileMode(420), modTime: time.Unix(1500478348, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_reporting_parameters.xml", size: 1373, mode: os.FileMode(420), modTime: time.Unix(1500407832, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5492,7 +5492,7 @@ func templatesCat1R3_1_result_valueXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1497309214, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1497276827, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5527,7 +5527,7 @@ func templatesCat1R3_1_resultsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_results.xml", size: 972, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_results.xml", size: 972, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5545,7 +5545,7 @@ func templatesCat1R3_1_telecomXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1492793736, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5749,7 +5749,7 @@ func templatesCat1R3_1Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r3_1/cat1.xml", size: 7017, mode: os.FileMode(420), modTime: time.Unix(1500478348, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r3_1/cat1.xml", size: 7017, mode: os.FileMode(420), modTime: time.Unix(1500407832, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5766,7 +5766,7 @@ func templatesCat1R4_Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_.xml", size: 48, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5796,7 +5796,7 @@ func templatesCat1R4_216840111388310202431Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.1.xml", size: 677, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.1.xml", size: 677, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5827,7 +5827,7 @@ func templatesCat1R4_21684011138831020243103Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.103.xml", size: 724, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5910,7 +5910,7 @@ func templatesCat1R4_21684011138831020243105Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3131, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.105.xml", size: 3131, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -5979,7 +5979,7 @@ func templatesCat1R4_2168401113883102024312Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2402, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.12.xml", size: 2402, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6069,7 +6069,7 @@ func templatesCat1R4_21684011138831020243135Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.135.xml", size: 3898, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.135.xml", size: 3898, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6124,7 +6124,7 @@ func templatesCat1R4_21684011138831020243140Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.140.xml", size: 1919, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.140.xml", size: 1919, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6159,7 +6159,7 @@ func templatesCat1R4_21684011138831020243144Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.144.xml", size: 975, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.144.xml", size: 975, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6199,7 +6199,7 @@ func templatesCat1R4_21684011138831020243145Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.145.xml", size: 1120, mode: os.FileMode(420), modTime: time.Unix(1498066845, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.145.xml", size: 1120, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6243,7 +6243,7 @@ func templatesCat1R4_2168401113883102024317Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1323, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.17.xml", size: 1323, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6283,7 +6283,7 @@ func templatesCat1R4_2168401113883102024318Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1218, mode: os.FileMode(420), modTime: time.Unix(1498066845, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.18.xml", size: 1218, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6331,7 +6331,7 @@ func templatesCat1R4_216840111388310202432Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1289, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.2.xml", size: 1289, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6377,7 +6377,7 @@ func templatesCat1R4_2168401113883102024322Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.22.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.22.xml", size: 1366, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6524,7 +6524,7 @@ func templatesCat1R4_2168401113883102024323Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.23.xml", size: 7814, mode: os.FileMode(420), modTime: time.Unix(1500936757, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.23.xml", size: 7814, mode: os.FileMode(420), modTime: time.Unix(1500921728, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6567,7 +6567,7 @@ func templatesCat1R4_216840111388310202433Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1108, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.3.xml", size: 1108, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6607,7 +6607,7 @@ func templatesCat1R4_2168401113883102024331Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1088, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.31.xml", size: 1088, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6643,7 +6643,7 @@ func templatesCat1R4_2168401113883102024332Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.32.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6681,7 +6681,7 @@ func templatesCat1R4_2168401113883102024337Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.37.xml", size: 995, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.37.xml", size: 995, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6718,7 +6718,7 @@ func templatesCat1R4_2168401113883102024338Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.38.xml", size: 981, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.38.xml", size: 981, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6767,7 +6767,7 @@ func templatesCat1R4_216840111388310202434Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1251, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.4.xml", size: 1251, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6827,7 +6827,7 @@ func templatesCat1R4_2168401113883102024341Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1917, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.41.xml", size: 1917, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6881,7 +6881,7 @@ func templatesCat1R4_2168401113883102024342Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1904, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.42.xml", size: 1904, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6921,7 +6921,7 @@ func templatesCat1R4_2168401113883102024343Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1194, mode: os.FileMode(420), modTime: time.Unix(1501692391, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.43.xml", size: 1194, mode: os.FileMode(420), modTime: time.Unix(1501706195, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -6962,7 +6962,7 @@ func templatesCat1R4_2168401113883102024344Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1245, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.44.xml", size: 1245, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7013,7 +7013,7 @@ func templatesCat1R4_2168401113883102024345Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1709, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.45.xml", size: 1709, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7059,7 +7059,7 @@ func templatesCat1R4_2168401113883102024346Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1237, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.46.xml", size: 1237, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7122,7 +7122,7 @@ func templatesCat1R4_2168401113883102024347Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2201, mode: os.FileMode(420), modTime: time.Unix(1497464416, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.47.xml", size: 2201, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7152,7 +7152,7 @@ func templatesCat1R4_2168401113883102024351Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.51.xml", size: 616, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7184,7 +7184,7 @@ func templatesCat1R4_2168401113883102024354Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.54.xml", size: 797, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7218,7 +7218,7 @@ func templatesCat1R4_2168401113883102024355Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.55.xml", size: 813, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7254,7 +7254,7 @@ func templatesCat1R4_2168401113883102024359Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1065, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.59.xml", size: 1065, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7306,7 +7306,7 @@ func templatesCat1R4_2168401113883102024362Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1711, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.62.xml", size: 1711, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7343,7 +7343,7 @@ func templatesCat1R4_2168401113883102024363Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1500917575, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.63.xml", size: 1016, mode: os.FileMode(420), modTime: time.Unix(1500921728, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7391,7 +7391,7 @@ func templatesCat1R4_2168401113883102024364Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.64.xml", size: 1567, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.64.xml", size: 1567, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7438,7 +7438,7 @@ func templatesCat1R4_216840111388310202437Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1520, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.7.xml", size: 1520, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7485,7 +7485,7 @@ func templatesCat1R4_2168401113883102024381Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1517, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.81.xml", size: 1517, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7532,7 +7532,7 @@ func templatesCat1R4_2168401113883102024382Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.82.xml", size: 1499, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.82.xml", size: 1499, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7590,7 +7590,7 @@ func templatesCat1R4_216840111388310202439Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.9.xml", size: 1784, mode: os.FileMode(420), modTime: time.Unix(1497493486, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_2.16.840.1.113883.10.20.24.3.9.xml", size: 1784, mode: os.FileMode(420), modTime: time.Unix(1497535355, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7616,7 +7616,7 @@ func templatesCat1R4_addressXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_address.xml", size: 291, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7664,7 +7664,7 @@ func templatesCat1R4_authorXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_author.xml", size: 814, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7708,7 +7708,7 @@ func templatesCat1R4_codeXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_code.xml", size: 1337, mode: os.FileMode(420), modTime: time.Unix(1499962120, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_code.xml", size: 1337, mode: os.FileMode(420), modTime: time.Unix(1499956862, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7734,7 +7734,7 @@ func templatesCat1R4_fulfillsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_fulfills.xml", size: 424, mode: os.FileMode(420), modTime: time.Unix(1497455974, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_fulfills.xml", size: 424, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7752,7 +7752,7 @@ func templatesCat1R4_idXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_id.xml", size: 84, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7832,7 +7832,7 @@ func templatesCat1R4_measuresXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_measures.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1500656086, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_measures.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1500561990, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7862,7 +7862,7 @@ func templatesCat1R4_medication_detailsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_medication_details.xml", size: 594, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7901,7 +7901,7 @@ func templatesCat1R4_medication_dispenseXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_medication_dispense.xml", size: 1097, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7924,7 +7924,7 @@ func templatesCat1R4_ordinalityXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_ordinality.xml", size: 406, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7955,7 +7955,7 @@ func templatesCat1R4_organizationXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_organization.xml", size: 378, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -7992,7 +7992,7 @@ func templatesCat1R4_patient_dataXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_patient_data.xml", size: 625, mode: os.FileMode(420), modTime: time.Unix(1500478348, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_patient_data.xml", size: 625, mode: os.FileMode(420), modTime: time.Unix(1500407832, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8075,7 +8075,7 @@ func templatesCat1R4_providersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_providers.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_providers.xml", size: 2482, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8110,7 +8110,7 @@ func templatesCat1R4_reasonXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_reason.xml", size: 966, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8192,7 +8192,7 @@ func templatesCat1R4_record_targetXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1500300824, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_record_target.xml", size: 2767, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8238,7 +8238,7 @@ func templatesCat1R4_reporting_parametersXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_reporting_parameters.xml", size: 1322, mode: os.FileMode(420), modTime: time.Unix(1500656086, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_reporting_parameters.xml", size: 1322, mode: os.FileMode(420), modTime: time.Unix(1500561990, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8270,7 +8270,7 @@ func templatesCat1R4_result_valueXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1501691853, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_result_value.xml", size: 654, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8305,7 +8305,7 @@ func templatesCat1R4_resultsXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_results.xml", size: 972, mode: os.FileMode(420), modTime: time.Unix(1501789861, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_results.xml", size: 972, mode: os.FileMode(420), modTime: time.Unix(1502200586, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8323,7 +8323,7 @@ func templatesCat1R4_telecomXml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1497393183, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/_telecom.xml", size: 65, mode: os.FileMode(420), modTime: time.Unix(1497469783, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -8527,7 +8527,7 @@ func templatesCat1R4Cat1Xml() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "templates/cat1/r4/cat1.xml", size: 7017, mode: os.FileMode(420), modTime: time.Unix(1501692391, 0)}
+	info := bindataFileInfo{name: "templates/cat1/r4/cat1.xml", size: 7017, mode: os.FileMode(420), modTime: time.Unix(1501706195, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -9214,7 +9214,7 @@ func hqmf_template_oid_mapJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_template_oid_map.json", size: 20534, mode: os.FileMode(420), modTime: time.Unix(1494432774, 0)}
+	info := bindataFileInfo{name: "hqmf_template_oid_map.json", size: 20534, mode: os.FileMode(420), modTime: time.Unix(1475778985, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -10691,7 +10691,7 @@ func hqmf_qrda_oidsJson() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_qrda_oids.json", size: 43927, mode: os.FileMode(420), modTime: time.Unix(1494432774, 0)}
+	info := bindataFileInfo{name: "hqmf_qrda_oids.json", size: 43927, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -10917,7 +10917,7 @@ func hqmf_qrda_oids_r3_1Json() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "hqmf_qrda_oids_r3_1.json", size: 5727, mode: os.FileMode(420), modTime: time.Unix(1494432774, 0)}
+	info := bindataFileInfo{name: "hqmf_qrda_oids_r3_1.json", size: 5727, mode: os.FileMode(420), modTime: time.Unix(1493912411, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/importer/assessment.go
+++ b/importer/assessment.go
@@ -9,7 +9,7 @@ import (
 func AssessmentPerformedExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	assessmentPerformed := models.Assessment{}
 	assessmentPerformed.Entry = *entry
-	
+
 	var codePath = xpath.Compile("cda:code")
 	ExtractCodes(&assessmentPerformed.Entry.Coded, entryElement, codePath)
 	ExtractReasonOrNegation(&assessmentPerformed.Entry, entryElement)

--- a/importer/communications.go
+++ b/importer/communications.go
@@ -3,7 +3,7 @@ package importer
 import (
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/jbowtie/gokogiri/xpath"
-	"github.com/pebbe/util"
+
 	"github.com/projectcypress/cdatools/models"
 )
 
@@ -25,7 +25,9 @@ func CommunicationExtractor(entry *models.Entry, entryElement xml.Node) interfac
 
 func findCommunicationDirection(entryElement xml.Node) string {
 	node, err := entryElement.Search("./cda:templateId")
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 	switch node[0].Attr("root") {
 	case "2.16.840.1.113883.10.20.24.3.3":
 		return "communication_from_provider_to_patient"
@@ -40,7 +42,9 @@ func findCommunicationDirection(entryElement xml.Node) string {
 
 func extractReferences(entry *models.Entry, entryElement xml.Node) {
 	refs, err := entryElement.Search("./sdtc:inFulfillmentOf1")
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 
 	for _, ref := range refs {
 		reference := models.Reference{}
@@ -50,13 +54,17 @@ func extractReferences(entry *models.Entry, entryElement xml.Node) {
 		}
 
 		ar, err := ref.Search("./sdtc:actReference")
-		util.CheckErr(err)
+		if err != nil {
+			panic(err.Error())
+		}
 		switch ar[0].Attr("classCode") {
 		case "ACT":
 			reference.ReferencedType = "Procedure"
 		}
 		idElem, err := ref.Search("./sdtc:actReference/sdtc:id")
-		util.CheckErr(err)
+		if err != nil {
+			panic(err.Error())
+		}
 		reference.ReferencedID = idElem[0].Attr("extension")
 		reference.ExportedRef = idElem[0].Attr("extension")
 		entry.References = append(entry.References, reference)

--- a/importer/conditions.go
+++ b/importer/conditions.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/jbowtie/gokogiri/xpath"
-	"github.com/pebbe/util"
+
 	"github.com/projectcypress/cdatools/models"
 )
 
@@ -20,7 +20,9 @@ func GestationalAgeExtractor(entry *models.Entry, entryElement xml.Node) interfa
 	ExtractValues(&gestationalAge.Entry, entryElement, valueXPath)
 
 	gestationalAgeScalar, err := strconv.Atoi(gestationalAge.Entry.Values[0].Scalar)
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 	switch gestationalAgeScalar {
 	case 39:
 		entry.Codes["SNOMED-CT"] = []string{"80487005"}

--- a/importer/encounter.go
+++ b/importer/encounter.go
@@ -3,7 +3,7 @@ package importer
 import (
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/jbowtie/gokogiri/xpath"
-	"github.com/pebbe/util"
+
 	"github.com/projectcypress/cdatools/models"
 )
 
@@ -80,7 +80,9 @@ func extractFacility(encounter *models.Encounter, entryElement xml.Node) {
 
 		addressXPath := xpath.Compile("cda:addr")
 		addressElements, err := participantElement.Search(addressXPath)
-		util.CheckErr(err)
+		if err != nil {
+			panic(err.Error())
+		}
 		facility.Addresses = make([]models.Address, len(addressElements))
 		for i, addressElement := range addressElements {
 			facility.Addresses[i] = ImportAddress(addressElement)
@@ -88,7 +90,9 @@ func extractFacility(encounter *models.Encounter, entryElement xml.Node) {
 
 		telecomXPath := xpath.Compile("cda:telecom")
 		telecomElements, err := participantElement.Search(telecomXPath)
-		util.CheckErr(err)
+		if err != nil {
+			panic(err.Error())
+		}
 		facility.Telecoms = make([]models.Telecom, len(telecomElements))
 		for i, telecomElement := range telecomElements {
 			facility.Telecoms[i] = ImportTelecom(telecomElement)

--- a/importer/locatable.go
+++ b/importer/locatable.go
@@ -3,7 +3,7 @@ package importer
 import (
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/jbowtie/gokogiri/xpath"
-	"github.com/pebbe/util"
+
 	"github.com/projectcypress/cdatools/models"
 )
 
@@ -11,7 +11,9 @@ func ImportAddress(addressElement xml.Node) models.Address {
 	var address = models.Address{}
 	address.Use = addressElement.Attr("use")
 	streetNameElements, err := addressElement.Search(xpath.Compile("cda:streetAddressLine"))
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 	address.Street = make([]string, len(streetNameElements))
 	for i, streetNameElement := range streetNameElements {
 		address.Street[i] = streetNameElement.Content()

--- a/importer/medical_equipment.go
+++ b/importer/medical_equipment.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/jbowtie/gokogiri/xpath"
-	"github.com/pebbe/util"
+
 	"github.com/projectcypress/cdatools/models"
 )
 
@@ -31,7 +31,9 @@ func MedicalEquipmentExtractor(entry *models.Entry, entryElement xml.Node) inter
 func extractManufacturer(medicalEquipment *models.MedicalEquipment, entryElement xml.Node) {
 	mfXPath := xpath.Compile("./cda:participant/cda:participantRole/cda:scopingEntity/cda:desc")
 	manufacturerElements, err := entryElement.Search(mfXPath)
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 
 	for _, MFElement := range manufacturerElements {
 		manufacturerAttr := MFElement.Attribute("inner_text")
@@ -44,7 +46,9 @@ func extractManufacturer(medicalEquipment *models.MedicalEquipment, entryElement
 func extractAnatomicalStructure(medicalEquipment *models.MedicalEquipment, entryElement xml.Node) {
 	asXPath := xpath.Compile("./cda:targetSiteCode")
 	asElements, err := entryElement.Search(asXPath)
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 
 	for _, ASElement := range asElements {
 		codeElement := ASElement.Attribute("code")

--- a/importer/medication.go
+++ b/importer/medication.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/jbowtie/gokogiri/xml"
 	"github.com/jbowtie/gokogiri/xpath"
-	"github.com/pebbe/util"
 	"github.com/projectcypress/cdatools/models"
 )
 
@@ -99,7 +98,9 @@ func extractAdministrationTiming(medication *models.Medication, entryElement xml
 		institutionSpecifiedAttr := adminTimingElement.Attribute("institutionSpecified")
 		if institutionSpecifiedAttr != nil {
 			institutionSpecified, err := strconv.ParseBool(institutionSpecifiedAttr.String())
-			util.CheckErr(err)
+			if err != nil {
+				panic(err.Error())
+			}
 			medication.AdministrationTiming.InstitutionSpecified = institutionSpecified
 		}
 		periodXPath := xpath.Compile("./cda:period")
@@ -125,7 +126,9 @@ func extractOrderInformation(medication *models.Medication, entryElement xml.Nod
 
 	if oiElement != nil {
 		fills, err := strconv.ParseInt(FirstElementContent(xpath.Compile("./@value"), oiElement), 10, 64)
-		util.CheckErr(err)
+		if err != nil {
+			panic(err.Error())
+		}
 		medication.AllowedAdministrations = &fills
 	}
 }
@@ -139,7 +142,9 @@ func extractSupplyInformation(medication *models.Medication, entryElement xml.No
 		//provider information not captured, unsure if necessary
 		oi.OrderNumber = FirstElementContent(xpath.Compile("./cda:id/@root"), oiElement)
 		fills, err := strconv.ParseInt(FirstElementContent(xpath.Compile("./cda:repeatNumber/@value"), oiElement), 10, 64)
-		util.CheckErr(err)
+		if err != nil {
+			panic(err.Error())
+		}
 		oi.Fills = fills
 		oi.OrderDate = GetTimestamp(xpath.Compile("./cda:effectiveTime/cda:low/@value"), oiElement)
 
@@ -154,7 +159,9 @@ func extractSupplyInformation(medication *models.Medication, entryElement xml.No
 func extractFulfillmentHistory(medication *models.Medication, entryElement xml.Node) {
 	fhXPath := xpath.Compile("./cda:entryRelationship/cda:supply[@moodCode='EVN']")
 	fulfillmentElements, err := entryElement.Search(fhXPath)
-	util.CheckErr(err)
+	if err != nil {
+		panic(err.Error())
+	}
 	if len(fulfillmentElements) > 0 {
 		for _, fhElement := range fulfillmentElements {
 			if fhElement != nil {
@@ -165,7 +172,9 @@ func extractFulfillmentHistory(medication *models.Medication, entryElement xml.N
 				fillNumber := FirstElementContent(xpath.Compile("./cda:entryRelationship[@typeCode='COMP']/cda:sequenceNumber/@value"), fhElement)
 				if fillNumber != "" {
 					fillnumber, err := strconv.ParseInt(fillNumber, 10, 64)
-					util.CheckErr(err)
+					if err != nil {
+						panic(err.Error())
+					}
 					fh.FillNumber = fillnumber
 				}
 

--- a/importer/procedure.go
+++ b/importer/procedure.go
@@ -34,7 +34,7 @@ func ProcedurePerformedExtractor(entry *models.Entry, entryElement xml.Node) int
 
 	extractBaseProcedure(&procedurePerformed, entryElement)
 	extractIncisionTime(&procedurePerformed, entryElement)
-	
+
 	scalarPath := xpath.Compile("cda:entryRelationship/cda:observation[./cda:templateId/@root = '2.16.840.1.113883.10.20.24.3.87']/cda:value")
 	ExtractValues(&procedurePerformed.Entry, entryElement, scalarPath)
 	return procedurePerformed


### PR DESCRIPTION
This will probably need to have some changes done to go-cda-tools, since there's some ruby code in there that checks the return string contents to see if the importer failed, and this code changes that some.

The main reason for this change is that CheckErr calls `log.Fatal` when the error passed to it isn't `nil`, which will call `os.Exit` after logging the message. This will kill anything using this library, which is undesirable. Instead, we can recover from panics.