### PR TITLE
Handle when gender is nullFlavor="UNK"

### DIFF
--- a/importer/demographics.go
+++ b/importer/demographics.go
@@ -11,8 +11,24 @@ func ExtractDemographics(patient *models.Record, patientElement xml.Node) {
 	patient.First = FirstElementContent(firstNameXPath, patientElement)
 	var lastNameXPath = xpath.Compile("cda:name/cda:family")
 	patient.Last = FirstElementContent(lastNameXPath, patientElement)
+
 	var genderXPath = xpath.Compile("cda:administrativeGenderCode/@code")
-	patient.Gender = FirstElementContent(genderXPath, patientElement)
+	genderResults, err := patientElement.Search(genderXPath)
+	if err != nil {
+		panic(err.Error())
+	}
+	if len(genderResults) == 0 {
+		genderResults, err = patientElement.Search(xpath.Compile("cda:administrativeGenderCode/@nullFlavor"))
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+	if len(genderResults) == 0 {
+		patient.Gender = "NULL"
+	} else {
+		firstNode := genderResults[0]
+		patient.Gender = firstNode.Content()
+	}
 	var birthTimeXPath = xpath.Compile("cda:birthTime/@value")
 	patient.BirthDate = GetTimestamp(birthTimeXPath, patientElement)
 

--- a/importer/importer_test.go
+++ b/importer/importer_test.go
@@ -49,6 +49,7 @@ func (i *ImporterSuite) TestExtractDemograpics(c *C) {
 	c.Assert(i.patient.Race.CodeSystem, Equals, "CDC Race and Ethnicity")
 	c.Assert(i.patient.Ethnicity.Code, Equals, "2186-5")
 	c.Assert(i.patient.Ethnicity.CodeSystem, Equals, "CDC Race and Ethnicity")
+	c.Assert(i.patient.Gender, Equals, "M")
 }
 
 func (i *ImporterSuite) TestExtractEncountersPerformed(c *C) {


### PR DESCRIPTION
If there is a nullFlavor attribute provided for gender, then patient gender will be set to its contents (UNK). Otherwise, if no gender code is specified and nullFlavor is not provided, patient gender is set to NULL.