### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/importer/transfer.go
+++ b/importer/transfer.go
@@ -6,7 +6,7 @@ import (
 	"github.com/projectcypress/cdatools/models"
 )
 
-// returns Encounter with TransferFrom field
+// TransferFromExtractor returns Encounter with TransferFrom field
 func TransferFromExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	transferFromEncounter := models.Encounter{}
 	transferFromEncounter.Entry = *entry
@@ -21,7 +21,7 @@ func TransferFromExtractor(entry *models.Entry, entryElement xml.Node) interface
 	return transferFromEncounter
 }
 
-// returns Encounter with TransferTo field
+// TransferToExtractor returns Encounter with TransferTo field
 func TransferToExtractor(entry *models.Entry, entryElement xml.Node) interface{} {
 	transferToEncounter := models.Encounter{}
 	transferToEncounter.Entry = *entry

--- a/models/entry.go
+++ b/models/entry.go
@@ -66,7 +66,7 @@ func (entry *Entry) GetEntry() *Entry {
 	return entry
 }
 
-// returns codeDisplay. also returns true if code display was found and false if not found
+// GetCodeDisplay returns codeDisplay. also returns true if code display was found and false if not found
 func (e *Entry) GetCodeDisplay(codeType string) (CodeDisplay, error) {
 	for _, codeDisplay := range e.CodeDisplays {
 		if codeDisplay.CodeType == codeType {

--- a/models/models.go
+++ b/models/models.go
@@ -21,7 +21,7 @@ func init() {
 	hds.importHQMFTemplateJSON()
 }
 
-// Returns an Hds with properly populated maps.
+// NewHds returns an Hds with properly populated maps.
 func NewHds() *HdsMaps {
 	return hds
 }


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?